### PR TITLE
Add scene preset tools and get_input_volume (Phase B)

### DIFF
--- a/internal/mcp/interfaces.go
+++ b/internal/mcp/interfaces.go
@@ -49,6 +49,10 @@ type OBSClient interface {
 	// Status
 	GetOBSStatus() (*obs.OBSStatus, error)
 
+	// Scene preset operations
+	CaptureSceneState(sceneName string) ([]obs.SourceState, error)
+	ApplyScenePreset(sceneName string, sources []obs.SourceState) error
+
 	// Event handling
 	SetEventCallback(callback obs.EventCallback)
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/ironystock/agentic-obs/internal/obs"
+	"github.com/ironystock/agentic-obs/internal/storage"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -41,6 +43,28 @@ type SetVolumeInput struct {
 	InputName string   `json:"input_name"`
 	VolumeDb  *float64 `json:"volume_db,omitempty"`
 	VolumeMul *float64 `json:"volume_mul,omitempty"`
+}
+
+// ListPresetsInput is the input for listing scene presets
+type ListPresetsInput struct {
+	SceneName string `json:"scene_name,omitempty"`
+}
+
+// PresetNameInput is the input for preset operations by name
+type PresetNameInput struct {
+	PresetName string `json:"preset_name"`
+}
+
+// RenamePresetInput is the input for renaming a preset
+type RenamePresetInput struct {
+	OldName string `json:"old_name"`
+	NewName string `json:"new_name"`
+}
+
+// SavePresetInput is the input for saving a scene preset
+type SavePresetInput struct {
+	PresetName string `json:"preset_name"`
+	SceneName  string `json:"scene_name"`
 }
 
 // registerToolHandlers registers all MCP tool handlers with the server
@@ -201,6 +225,63 @@ func (s *Server) registerToolHandlers() {
 			Description: "Get overall OBS status including version, connection state, and active scene",
 		},
 		s.handleGetOBSStatus,
+	)
+
+	// Scene preset tools
+	mcpsdk.AddTool(s.mcpServer,
+		&mcpsdk.Tool{
+			Name:        "list_scene_presets",
+			Description: "List all saved scene presets, optionally filtered by scene name",
+		},
+		s.handleListScenePresets,
+	)
+
+	mcpsdk.AddTool(s.mcpServer,
+		&mcpsdk.Tool{
+			Name:        "get_preset_details",
+			Description: "Get detailed information about a specific scene preset including source states",
+		},
+		s.handleGetPresetDetails,
+	)
+
+	mcpsdk.AddTool(s.mcpServer,
+		&mcpsdk.Tool{
+			Name:        "delete_scene_preset",
+			Description: "Delete a saved scene preset by name",
+		},
+		s.handleDeleteScenePreset,
+	)
+
+	mcpsdk.AddTool(s.mcpServer,
+		&mcpsdk.Tool{
+			Name:        "rename_scene_preset",
+			Description: "Rename an existing scene preset",
+		},
+		s.handleRenameScenePreset,
+	)
+
+	mcpsdk.AddTool(s.mcpServer,
+		&mcpsdk.Tool{
+			Name:        "save_scene_preset",
+			Description: "Save the current state of a scene as a named preset",
+		},
+		s.handleSaveScenePreset,
+	)
+
+	mcpsdk.AddTool(s.mcpServer,
+		&mcpsdk.Tool{
+			Name:        "apply_scene_preset",
+			Description: "Apply a saved preset to restore source visibility states",
+		},
+		s.handleApplyScenePreset,
+	)
+
+	mcpsdk.AddTool(s.mcpServer,
+		&mcpsdk.Tool{
+			Name:        "get_input_volume",
+			Description: "Get the current volume level of an audio input (returns dB and multiplier values)",
+		},
+		s.handleGetInputVolume,
 	)
 
 	log.Println("Tool handlers registered successfully")
@@ -441,5 +522,176 @@ func (s *Server) handleSetInputVolume(ctx context.Context, request *mcpsdk.CallT
 
 	return nil, SimpleResult{
 		Message: fmt.Sprintf("Successfully set volume for input: %s", input.InputName),
+	}, nil
+}
+
+// Scene preset tool handlers
+
+func (s *Server) handleListScenePresets(ctx context.Context, request *mcpsdk.CallToolRequest, input ListPresetsInput) (*mcpsdk.CallToolResult, any, error) {
+	log.Printf("Listing scene presets (filter: %s)", input.SceneName)
+
+	presets, err := s.storage.ListScenePresets(ctx, input.SceneName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list scene presets: %w", err)
+	}
+
+	// Convert to simpler response format (without full source details)
+	result := make([]map[string]interface{}, len(presets))
+	for i, p := range presets {
+		result[i] = map[string]interface{}{
+			"id":         p.ID,
+			"name":       p.Name,
+			"scene_name": p.SceneName,
+			"created_at": p.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		}
+	}
+
+	return nil, map[string]interface{}{
+		"presets": result,
+		"count":   len(presets),
+	}, nil
+}
+
+func (s *Server) handleGetPresetDetails(ctx context.Context, request *mcpsdk.CallToolRequest, input PresetNameInput) (*mcpsdk.CallToolResult, any, error) {
+	log.Printf("Getting preset details for: %s", input.PresetName)
+
+	preset, err := s.storage.GetScenePreset(ctx, input.PresetName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get preset details: %w", err)
+	}
+
+	return nil, map[string]interface{}{
+		"id":         preset.ID,
+		"name":       preset.Name,
+		"scene_name": preset.SceneName,
+		"sources":    preset.Sources,
+		"created_at": preset.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	}, nil
+}
+
+func (s *Server) handleDeleteScenePreset(ctx context.Context, request *mcpsdk.CallToolRequest, input PresetNameInput) (*mcpsdk.CallToolResult, any, error) {
+	log.Printf("Deleting scene preset: %s", input.PresetName)
+
+	if err := s.storage.DeleteScenePreset(ctx, input.PresetName); err != nil {
+		return nil, nil, fmt.Errorf("failed to delete preset: %w", err)
+	}
+
+	return nil, SimpleResult{
+		Message: fmt.Sprintf("Successfully deleted preset: %s", input.PresetName),
+	}, nil
+}
+
+func (s *Server) handleRenameScenePreset(ctx context.Context, request *mcpsdk.CallToolRequest, input RenamePresetInput) (*mcpsdk.CallToolResult, any, error) {
+	log.Printf("Renaming preset from '%s' to '%s'", input.OldName, input.NewName)
+
+	if err := s.storage.RenameScenePreset(ctx, input.OldName, input.NewName); err != nil {
+		return nil, nil, fmt.Errorf("failed to rename preset: %w", err)
+	}
+
+	return nil, SimpleResult{
+		Message: fmt.Sprintf("Successfully renamed preset from '%s' to '%s'", input.OldName, input.NewName),
+	}, nil
+}
+
+func (s *Server) handleGetInputVolume(ctx context.Context, request *mcpsdk.CallToolRequest, input InputNameInput) (*mcpsdk.CallToolResult, any, error) {
+	log.Printf("Getting volume for input: %s", input.InputName)
+
+	volumeDb, volumeMul, err := s.obsClient.GetInputVolume(input.InputName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get input volume: %w", err)
+	}
+
+	return nil, map[string]interface{}{
+		"input_name": input.InputName,
+		"volume_db":  volumeDb,
+		"volume_mul": volumeMul,
+	}, nil
+}
+
+func (s *Server) handleSaveScenePreset(ctx context.Context, request *mcpsdk.CallToolRequest, input SavePresetInput) (*mcpsdk.CallToolResult, any, error) {
+	log.Printf("Saving scene preset '%s' for scene '%s'", input.PresetName, input.SceneName)
+
+	// Capture current scene state from OBS
+	states, err := s.obsClient.CaptureSceneState(input.SceneName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to capture scene state: %w", err)
+	}
+
+	// Convert OBS source states to storage format
+	sources := make([]storage.SourceState, len(states))
+	for i, state := range states {
+		sources[i] = storage.SourceState{
+			Name:    state.Name,
+			Visible: state.Enabled,
+		}
+	}
+
+	// Create preset in storage
+	preset := storage.ScenePreset{
+		Name:      input.PresetName,
+		SceneName: input.SceneName,
+		Sources:   sources,
+	}
+
+	id, err := s.storage.CreateScenePreset(ctx, preset)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to save preset: %w", err)
+	}
+
+	return nil, map[string]interface{}{
+		"id":           id,
+		"preset_name":  input.PresetName,
+		"scene_name":   input.SceneName,
+		"source_count": len(sources),
+		"message":      fmt.Sprintf("Successfully saved preset '%s' with %d sources", input.PresetName, len(sources)),
+	}, nil
+}
+
+func (s *Server) handleApplyScenePreset(ctx context.Context, request *mcpsdk.CallToolRequest, input PresetNameInput) (*mcpsdk.CallToolResult, any, error) {
+	log.Printf("Applying scene preset: %s", input.PresetName)
+
+	// Load preset from storage
+	preset, err := s.storage.GetScenePreset(ctx, input.PresetName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load preset: %w", err)
+	}
+
+	// Get current scene items to map names to IDs
+	scene, err := s.obsClient.GetSceneByName(preset.SceneName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get scene '%s': %w", preset.SceneName, err)
+	}
+
+	// Build name-to-ID map
+	nameToID := make(map[string]int)
+	for _, src := range scene.Sources {
+		nameToID[src.Name] = src.ID
+	}
+
+	// Convert storage format to OBS source states
+	obsStates := make([]obs.SourceState, 0, len(preset.Sources))
+	for _, src := range preset.Sources {
+		id, exists := nameToID[src.Name]
+		if !exists {
+			log.Printf("Warning: source '%s' not found in scene, skipping", src.Name)
+			continue
+		}
+		obsStates = append(obsStates, obs.SourceState{
+			ID:      id,
+			Name:    src.Name,
+			Enabled: src.Visible,
+		})
+	}
+
+	// Apply preset to OBS
+	if err := s.obsClient.ApplyScenePreset(preset.SceneName, obsStates); err != nil {
+		return nil, nil, fmt.Errorf("failed to apply preset: %w", err)
+	}
+
+	return nil, map[string]interface{}{
+		"preset_name":   input.PresetName,
+		"scene_name":    preset.SceneName,
+		"applied_count": len(obsStates),
+		"message":       fmt.Sprintf("Successfully applied preset '%s' to scene '%s'", input.PresetName, preset.SceneName),
 	}, nil
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2,12 +2,15 @@ package mcp
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ironystock/agentic-obs/internal/mcp/testutil"
+	"github.com/ironystock/agentic-obs/internal/storage"
 )
 
 // testServer creates a minimal test server with a mock OBS client.
@@ -671,5 +674,356 @@ func TestNilRequest(t *testing.T) {
 
 		_, _, err = server.handleGetOBSStatus(context.Background(), nil, struct{}{})
 		assert.NoError(t, err)
+	})
+}
+
+// testServerWithStorage creates a test server with mock OBS client and real storage.
+func testServerWithStorage(t *testing.T) (*Server, *testutil.MockOBSClient, *storage.DB) {
+	t.Helper()
+
+	mock := testutil.NewMockOBSClient()
+	mock.Connect()
+
+	// Create temp database
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := storage.New(context.Background(), storage.Config{Path: dbPath})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(dbPath)
+	})
+
+	server := &Server{
+		obsClient: mock,
+		storage:   db,
+		ctx:       context.Background(),
+	}
+
+	return server, mock, db
+}
+
+// Test scene preset tools
+
+func TestHandleListScenePresets(t *testing.T) {
+	t.Run("returns empty list initially", func(t *testing.T) {
+		server, _, _ := testServerWithStorage(t)
+
+		input := ListPresetsInput{}
+		_, result, err := server.handleListScenePresets(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+
+		resultMap, ok := result.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, 0, resultMap["count"])
+	})
+
+	t.Run("lists created presets", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		// Create a preset directly in storage
+		_, err := db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name:      "Test Preset",
+			SceneName: "Scene 1",
+			Sources:   []storage.SourceState{{Name: "Webcam", Visible: true}},
+		})
+		require.NoError(t, err)
+
+		input := ListPresetsInput{}
+		_, result, err := server.handleListScenePresets(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		resultMap := result.(map[string]interface{})
+		assert.Equal(t, 1, resultMap["count"])
+
+		presets := resultMap["presets"].([]map[string]interface{})
+		assert.Equal(t, "Test Preset", presets[0]["name"])
+	})
+
+	t.Run("filters by scene name", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		// Create presets for different scenes
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name: "Preset 1", SceneName: "Scene 1", Sources: []storage.SourceState{},
+		})
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name: "Preset 2", SceneName: "Scene 2", Sources: []storage.SourceState{},
+		})
+
+		input := ListPresetsInput{SceneName: "Scene 1"}
+		_, result, err := server.handleListScenePresets(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		resultMap := result.(map[string]interface{})
+		assert.Equal(t, 1, resultMap["count"])
+	})
+}
+
+func TestHandleGetPresetDetails(t *testing.T) {
+	t.Run("returns preset details", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		// Create a preset
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name:      "My Preset",
+			SceneName: "Gaming",
+			Sources:   []storage.SourceState{{Name: "Webcam", Visible: true}},
+		})
+
+		input := PresetNameInput{PresetName: "My Preset"}
+		_, result, err := server.handleGetPresetDetails(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		resultMap := result.(map[string]interface{})
+		assert.Equal(t, "My Preset", resultMap["name"])
+		assert.Equal(t, "Gaming", resultMap["scene_name"])
+		assert.NotNil(t, resultMap["sources"])
+	})
+
+	t.Run("returns error for non-existent preset", func(t *testing.T) {
+		server, _, _ := testServerWithStorage(t)
+
+		input := PresetNameInput{PresetName: "NonExistent"}
+		_, _, err := server.handleGetPresetDetails(context.Background(), nil, input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestHandleDeleteScenePreset(t *testing.T) {
+	t.Run("deletes preset successfully", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		// Create a preset
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name: "To Delete", SceneName: "Scene 1", Sources: []storage.SourceState{},
+		})
+
+		input := PresetNameInput{PresetName: "To Delete"}
+		_, result, err := server.handleDeleteScenePreset(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		simpleResult := result.(SimpleResult)
+		assert.Contains(t, simpleResult.Message, "To Delete")
+
+		// Verify preset was deleted
+		_, err = db.GetScenePreset(context.Background(), "To Delete")
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error for non-existent preset", func(t *testing.T) {
+		server, _, _ := testServerWithStorage(t)
+
+		input := PresetNameInput{PresetName: "NonExistent"}
+		_, _, err := server.handleDeleteScenePreset(context.Background(), nil, input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestHandleRenameScenePreset(t *testing.T) {
+	t.Run("renames preset successfully", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		// Create a preset
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name: "Old Name", SceneName: "Scene 1", Sources: []storage.SourceState{},
+		})
+
+		input := RenamePresetInput{OldName: "Old Name", NewName: "New Name"}
+		_, result, err := server.handleRenameScenePreset(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		simpleResult := result.(SimpleResult)
+		assert.Contains(t, simpleResult.Message, "New Name")
+
+		// Verify preset was renamed
+		preset, err := db.GetScenePreset(context.Background(), "New Name")
+		assert.NoError(t, err)
+		assert.Equal(t, "New Name", preset.Name)
+	})
+
+	t.Run("returns error for non-existent preset", func(t *testing.T) {
+		server, _, _ := testServerWithStorage(t)
+
+		input := RenamePresetInput{OldName: "NonExistent", NewName: "New Name"}
+		_, _, err := server.handleRenameScenePreset(context.Background(), nil, input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestHandleGetInputVolume(t *testing.T) {
+	t.Run("returns input volume", func(t *testing.T) {
+		server, mock := testServer(t)
+		mock.SetInputVolumeState("Microphone", -6.0)
+
+		input := InputNameInput{InputName: "Microphone"}
+		_, result, err := server.handleGetInputVolume(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		resultMap := result.(map[string]interface{})
+		assert.Equal(t, "Microphone", resultMap["input_name"])
+		assert.Equal(t, -6.0, resultMap["volume_db"])
+		assert.NotNil(t, resultMap["volume_mul"])
+	})
+
+	t.Run("returns error for non-existent input", func(t *testing.T) {
+		server, _ := testServer(t)
+
+		input := InputNameInput{InputName: "NonExistent"}
+		_, _, err := server.handleGetInputVolume(context.Background(), nil, input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestHandleSaveScenePreset(t *testing.T) {
+	t.Run("saves scene preset successfully", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		input := SavePresetInput{PresetName: "Gaming Setup", SceneName: "Scene 1"}
+		_, result, err := server.handleSaveScenePreset(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		resultMap := result.(map[string]interface{})
+		assert.Equal(t, "Gaming Setup", resultMap["preset_name"])
+		assert.Equal(t, "Scene 1", resultMap["scene_name"])
+		assert.NotNil(t, resultMap["id"])
+
+		// Verify preset was saved
+		preset, err := db.GetScenePreset(context.Background(), "Gaming Setup")
+		assert.NoError(t, err)
+		assert.Equal(t, "Scene 1", preset.SceneName)
+		assert.Len(t, preset.Sources, 2) // Scene 1 has 2 sources in mock
+	})
+
+	t.Run("returns error for non-existent scene", func(t *testing.T) {
+		server, _, _ := testServerWithStorage(t)
+
+		input := SavePresetInput{PresetName: "Test", SceneName: "NonExistent"}
+		_, _, err := server.handleSaveScenePreset(context.Background(), nil, input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("returns error for duplicate preset name", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		// Create a preset first
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name: "Duplicate", SceneName: "Scene 1", Sources: []storage.SourceState{},
+		})
+
+		input := SavePresetInput{PresetName: "Duplicate", SceneName: "Scene 1"}
+		_, _, err := server.handleSaveScenePreset(context.Background(), nil, input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "UNIQUE constraint failed")
+	})
+}
+
+func TestHandleApplyScenePreset(t *testing.T) {
+	t.Run("applies scene preset successfully", func(t *testing.T) {
+		server, mock, db := testServerWithStorage(t)
+
+		// Create a preset with specific source states
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name:      "Test Preset",
+			SceneName: "Scene 1",
+			Sources: []storage.SourceState{
+				{Name: "Webcam", Visible: false}, // Will be disabled
+				{Name: "Text", Visible: true},    // Will stay enabled
+			},
+		})
+
+		input := PresetNameInput{PresetName: "Test Preset"}
+		_, result, err := server.handleApplyScenePreset(context.Background(), nil, input)
+
+		assert.NoError(t, err)
+		resultMap := result.(map[string]interface{})
+		assert.Equal(t, "Test Preset", resultMap["preset_name"])
+		assert.Equal(t, "Scene 1", resultMap["scene_name"])
+
+		// Verify source states were applied
+		scene, _ := mock.GetSceneByName("Scene 1")
+		for _, src := range scene.Sources {
+			if src.Name == "Webcam" {
+				assert.False(t, src.Enabled)
+			}
+			if src.Name == "Text" {
+				assert.True(t, src.Enabled)
+			}
+		}
+	})
+
+	t.Run("returns error for non-existent preset", func(t *testing.T) {
+		server, _, _ := testServerWithStorage(t)
+
+		input := PresetNameInput{PresetName: "NonExistent"}
+		_, _, err := server.handleApplyScenePreset(context.Background(), nil, input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("skips sources not found in scene", func(t *testing.T) {
+		server, _, db := testServerWithStorage(t)
+
+		// Create a preset with a source that doesn't exist in the scene
+		db.CreateScenePreset(context.Background(), storage.ScenePreset{
+			Name:      "Preset With Missing Source",
+			SceneName: "Scene 1",
+			Sources: []storage.SourceState{
+				{Name: "Webcam", Visible: true},
+				{Name: "NonExistentSource", Visible: false}, // This source doesn't exist
+			},
+		})
+
+		input := PresetNameInput{PresetName: "Preset With Missing Source"}
+		_, result, err := server.handleApplyScenePreset(context.Background(), nil, input)
+
+		// Should succeed but only apply 1 source
+		assert.NoError(t, err)
+		resultMap := result.(map[string]interface{})
+		assert.Equal(t, 1, resultMap["applied_count"])
+	})
+}
+
+// Test complete preset workflow
+func TestPresetWorkflow(t *testing.T) {
+	t.Run("complete save and apply workflow", func(t *testing.T) {
+		server, mock, _ := testServerWithStorage(t)
+
+		// Save the current state of Scene 1
+		saveInput := SavePresetInput{PresetName: "Scene1 State", SceneName: "Scene 1"}
+		_, _, err := server.handleSaveScenePreset(context.Background(), nil, saveInput)
+		require.NoError(t, err)
+
+		// Modify the scene by toggling a source
+		mock.ToggleSourceVisibility("Scene 1", 1) // Toggle Webcam
+
+		// Apply the saved preset to restore original state
+		applyInput := PresetNameInput{PresetName: "Scene1 State"}
+		_, _, err = server.handleApplyScenePreset(context.Background(), nil, applyInput)
+		require.NoError(t, err)
+
+		// Verify the scene was restored
+		scene, _ := mock.GetSceneByName("Scene 1")
+		for _, src := range scene.Sources {
+			if src.ID == 1 {
+				assert.True(t, src.Enabled) // Should be restored to original state
+			}
+		}
 	})
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -693,7 +692,6 @@ func testServerWithStorage(t *testing.T) (*Server, *testutil.MockOBSClient, *sto
 
 	t.Cleanup(func() {
 		db.Close()
-		os.Remove(dbPath)
 	})
 
 	server := &Server{

--- a/internal/obs/commands.go
+++ b/internal/obs/commands.go
@@ -531,6 +531,8 @@ type SourceState struct {
 
 // CaptureSceneState captures the current state of all sources in a scene.
 // Returns source IDs, names, and their enabled (visible) states.
+// TODO: For scenes with >25 sources, consider implementing batch operations or
+// concurrent processing to improve performance.
 func (c *Client) CaptureSceneState(sceneName string) ([]SourceState, error) {
 	scene, err := c.GetSceneByName(sceneName)
 	if err != nil {
@@ -551,6 +553,9 @@ func (c *Client) CaptureSceneState(sceneName string) ([]SourceState, error) {
 
 // ApplyScenePreset applies source visibility states to a scene.
 // This sets each source's enabled state according to the provided states.
+// TODO: For scenes with >25 sources, consider implementing batch operations to improve
+// performance and provide better error handling (collect partial failures rather than
+// failing on first error).
 func (c *Client) ApplyScenePreset(sceneName string, sources []SourceState) error {
 	client, err := c.getClient()
 	if err != nil {

--- a/internal/obs/commands.go
+++ b/internal/obs/commands.go
@@ -521,3 +521,54 @@ type OBSStatus struct {
 	Frames           int     `json:"frames"`
 	DroppedFrames    int     `json:"dropped_frames"`
 }
+
+// SourceState represents the visibility state of a source for preset capture/apply.
+type SourceState struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+// CaptureSceneState captures the current state of all sources in a scene.
+// Returns source IDs, names, and their enabled (visible) states.
+func (c *Client) CaptureSceneState(sceneName string) ([]SourceState, error) {
+	scene, err := c.GetSceneByName(sceneName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to capture scene state: %w", err)
+	}
+
+	states := make([]SourceState, len(scene.Sources))
+	for i, src := range scene.Sources {
+		states[i] = SourceState{
+			ID:      src.ID,
+			Name:    src.Name,
+			Enabled: src.Enabled,
+		}
+	}
+
+	return states, nil
+}
+
+// ApplyScenePreset applies source visibility states to a scene.
+// This sets each source's enabled state according to the provided states.
+func (c *Client) ApplyScenePreset(sceneName string, sources []SourceState) error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	for _, src := range sources {
+		sceneItemID := src.ID
+		enabled := src.Enabled
+		_, err := client.SceneItems.SetSceneItemEnabled(&sceneitems.SetSceneItemEnabledParams{
+			SceneName:        &sceneName,
+			SceneItemId:      &sceneItemID,
+			SceneItemEnabled: &enabled,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to set visibility for source '%s' (ID %d): %w", src.Name, src.ID, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR implements **Phase B** of the 4-week implementation plan - Scene Presets.

- Add 7 new MCP tools (19 → 26 total):
  - `list_scene_presets` - List all saved presets with optional scene filter
  - `get_preset_details` - Get full preset details including source states
  - `delete_scene_preset` - Delete a preset by name
  - `rename_scene_preset` - Rename an existing preset
  - `save_scene_preset` - Capture current scene state as a preset
  - `apply_scene_preset` - Restore source visibility from saved preset
  - `get_input_volume` - Get audio input volume level (quick win)
- Add 2 new OBS commands for preset capture/apply
- Extend OBSClient interface and mock for testing
- Add comprehensive test coverage for all new tools

## Test plan

- [x] All existing tests pass
- [x] New tools tested with success and error cases
- [x] `go vet` passes
- [x] `gofmt` passes
- [x] Complete save/apply workflow tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)