### PR TITLE
Phase C: Agentic Screenshot Sources

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -23,15 +23,21 @@ agentic-obs/
 │   ├── mcp/
 │   │   ├── server.go      # MCP server initialization and lifecycle
 │   │   ├── tools.go       # MCP tool registration and handlers
-│   │   └── resources.go   # MCP resource handlers (scenes as resources)
+│   │   ├── resources.go   # MCP resource handlers (scenes as resources)
+│   │   └── interfaces.go  # OBSClient interface for testing
 │   ├── obs/
 │   │   ├── client.go      # OBS WebSocket client wrapper
 │   │   ├── commands.go    # OBS command implementations
 │   │   └── events.go      # OBS event handling and notification dispatch
-│   └── storage/
-│       ├── db.go          # SQLite database setup and migrations
-│       ├── scenes.go      # Scene preset persistence
-│       └── state.go       # Configuration and state management
+│   ├── storage/
+│   │   ├── db.go          # SQLite database setup and migrations
+│   │   ├── scenes.go      # Scene preset persistence
+│   │   ├── screenshots.go # Screenshot source and image persistence
+│   │   └── state.go       # Configuration and state management
+│   ├── http/
+│   │   └── server.go      # HTTP server for screenshot image serving
+│   └── screenshot/
+│       └── manager.go     # Background screenshot capture manager
 └── scripts/
     └── setup.sh           # Development setup helpers
 ```
@@ -138,7 +144,7 @@ Configuration & Presets
 - `resources/read` - Get detailed scene configuration
 - `resources/subscribe` - Subscribe to scene change notifications (future)
 
-### MCP Tools Implemented (26 tools)
+### MCP Tools Implemented (30 tools)
 
 Core tools for OBS control:
 - **Scene Management**: `list_scenes`, `set_current_scene`, `create_scene`, `remove_scene`
@@ -147,6 +153,7 @@ Core tools for OBS control:
 - **Sources**: `list_sources`, `toggle_source_visibility`, `get_source_settings`
 - **Audio**: `get_input_mute`, `toggle_input_mute`, `set_input_volume`, `get_input_volume`
 - **Scene Presets**: `save_scene_preset`, `list_scene_presets`, `get_preset_details`, `apply_scene_preset`, `rename_scene_preset`, `delete_scene_preset`
+- **Screenshot Sources**: `create_screenshot_source`, `remove_screenshot_source`, `list_screenshot_sources`, `configure_screenshot_cadence`
 - **Status**: `get_obs_status` (overall OBS connection and state)
 
 **Note:** Scenes are also exposed as MCP resources (`resources/list`), enabling notification support.
@@ -177,8 +184,14 @@ Core tools for OBS control:
 - 7 new tools: scene presets (6) + get_input_volume
 - Comprehensive test coverage with mock OBS client
 
+**Phase 3 (Complete):**
+- Agentic screenshot sources for AI visual monitoring
+- 4 new tools: `create_screenshot_source`, `remove_screenshot_source`, `list_screenshot_sources`, `configure_screenshot_cadence`
+- HTTP server for serving screenshots at `http://localhost:8765/screenshot/{name}`
+- Background capture manager with configurable cadence
+- Automatic cleanup to keep storage bounded
+
 **Future Enhancements:**
-- Agentic screenshot sources (AI visual monitoring)
 - Multi-instance OBS support (requires architecture refactor)
 - Additional resource types (sources, filters, transitions)
 - Automation rules and macros

--- a/README.md
+++ b/README.md
@@ -158,13 +158,22 @@ Example Claude Desktop configuration (`claude_desktop_config.json`):
 | `rename_scene_preset` | Rename an existing preset |
 | `delete_scene_preset` | Delete a saved preset |
 
+### Screenshot Sources (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `create_screenshot_source` | Create a periodic screenshot capture source for AI visual monitoring |
+| `remove_screenshot_source` | Stop and remove a screenshot capture source |
+| `list_screenshot_sources` | List all configured sources with status and HTTP URLs |
+| `configure_screenshot_cadence` | Update the capture interval for a screenshot source |
+
 ### Status & Monitoring (1 tool)
 
 | Tool | Description |
 |------|-------------|
 | `get_obs_status` | Get overall OBS status and connection info |
 
-**Total: 26 tools**
+**Total: 30 tools**
 
 ## Development
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -134,7 +134,7 @@ func (s *Server) Start() error {
 
 	go func() {
 		if err := s.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
-			// Log error but don't crash - the server will be marked as not running
+			log.Printf("HTTP server error: %v", err)
 			s.mu.Lock()
 			s.running = false
 			s.mu.Unlock()

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,0 +1,205 @@
+package http
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ironystock/agentic-obs/internal/storage"
+)
+
+// Config holds HTTP server configuration options.
+type Config struct {
+	// Host to bind to (default: "localhost")
+	Host string
+	// Port to listen on (default: 8765)
+	Port int
+}
+
+// DefaultConfig returns the default HTTP server configuration.
+func DefaultConfig() Config {
+	return Config{
+		Host: "localhost",
+		Port: 8765,
+	}
+}
+
+// Server provides HTTP endpoints for serving screenshot images.
+type Server struct {
+	storage    *storage.DB
+	httpServer *http.Server
+	addr       string
+	cfg        Config
+
+	mu       sync.RWMutex
+	running  bool
+	listener net.Listener
+}
+
+// NewServer creates a new HTTP server for serving screenshots.
+func NewServer(db *storage.DB, cfg Config) *Server {
+	if cfg.Host == "" {
+		cfg.Host = "localhost"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 8765
+	}
+
+	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+
+	s := &Server{
+		storage: db,
+		cfg:     cfg,
+		addr:    addr,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/screenshot/", s.handleScreenshot)
+	mux.HandleFunc("/health", s.handleHealth)
+
+	s.httpServer = &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	return s
+}
+
+// Start begins serving HTTP requests in a background goroutine.
+// Returns an error if the server is already running or fails to bind.
+func (s *Server) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		return fmt.Errorf("HTTP server already running")
+	}
+
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("failed to bind to %s: %w", s.addr, err)
+	}
+	s.listener = listener
+
+	// Update addr with actual bound address (useful if port was 0)
+	s.addr = listener.Addr().String()
+	s.httpServer.Addr = s.addr
+
+	s.running = true
+
+	go func() {
+		if err := s.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			// Log error but don't crash - the server will be marked as not running
+			s.mu.Lock()
+			s.running = false
+			s.mu.Unlock()
+		}
+	}()
+
+	return nil
+}
+
+// Stop gracefully shuts down the HTTP server.
+func (s *Server) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return nil
+	}
+	s.running = false
+	s.mu.Unlock()
+
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		return fmt.Errorf("failed to shutdown HTTP server: %w", err)
+	}
+
+	return nil
+}
+
+// GetAddr returns the base URL of the HTTP server.
+func (s *Server) GetAddr() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return fmt.Sprintf("http://%s", s.addr)
+}
+
+// GetScreenshotURL returns the full URL for a screenshot source.
+func (s *Server) GetScreenshotURL(sourceName string) string {
+	return fmt.Sprintf("%s/screenshot/%s", s.GetAddr(), sourceName)
+}
+
+// IsRunning returns whether the server is currently running.
+func (s *Server) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.running
+}
+
+// handleScreenshot serves the latest screenshot for a source.
+// URL pattern: GET /screenshot/{source_name}
+func (s *Server) handleScreenshot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract source name from path: /screenshot/{source_name}
+	path := strings.TrimPrefix(r.URL.Path, "/screenshot/")
+	if path == "" || path == "/" {
+		http.Error(w, "Source name required", http.StatusBadRequest)
+		return
+	}
+	sourceName := path
+
+	// Look up the screenshot source by name
+	source, err := s.storage.GetScreenshotSourceByName(r.Context(), sourceName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Screenshot source not found: %s", sourceName), http.StatusNotFound)
+		return
+	}
+
+	// Get the latest screenshot for this source
+	screenshot, err := s.storage.GetLatestScreenshot(r.Context(), source.ID)
+	if err != nil {
+		http.Error(w, "No screenshots available", http.StatusNotFound)
+		return
+	}
+
+	// Decode base64 image data
+	imageData, err := base64.StdEncoding.DecodeString(screenshot.ImageData)
+	if err != nil {
+		http.Error(w, "Failed to decode image data", http.StatusInternalServerError)
+		return
+	}
+
+	// Set appropriate headers
+	w.Header().Set("Content-Type", screenshot.MimeType)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(imageData)))
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("X-Screenshot-Source", sourceName)
+	w.Header().Set("X-Screenshot-Captured", screenshot.CapturedAt.Format(time.RFC3339))
+
+	// Write the image data
+	w.WriteHeader(http.StatusOK)
+	w.Write(imageData)
+}
+
+// handleHealth provides a simple health check endpoint.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`))
+}

--- a/internal/mcp/interfaces.go
+++ b/internal/mcp/interfaces.go
@@ -53,6 +53,10 @@ type OBSClient interface {
 	CaptureSceneState(sceneName string) ([]obs.SourceState, error)
 	ApplyScenePreset(sceneName string, sources []obs.SourceState) error
 
+	// Screenshot operations
+	TakeSourceScreenshot(opts obs.ScreenshotOptions) (string, error)
+	CreateBrowserSource(sceneName, sourceName string, settings obs.BrowserSourceSettings) (int, error)
+
 	// Event handling
 	SetEventCallback(callback obs.EventCallback)
 }

--- a/internal/mcp/testutil/mock_obs.go
+++ b/internal/mcp/testutil/mock_obs.go
@@ -34,24 +34,24 @@ type MockOBSClient struct {
 	streaming bool
 
 	// Error injection for testing error paths
-	ErrorOnConnect           error
-	ErrorOnGetSceneList      error
-	ErrorOnSetCurrentScene   error
-	ErrorOnCreateScene       error
-	ErrorOnRemoveScene       error
-	ErrorOnStartRecording    error
-	ErrorOnStopRecording     error
-	ErrorOnPauseRecording    error
-	ErrorOnResumeRecording   error
-	ErrorOnStartStreaming    error
-	ErrorOnStopStreaming     error
-	ErrorOnListSources       error
-	ErrorOnGetSourceSettings error
-	ErrorOnToggleVisibility  error
-	ErrorOnGetInputMute      error
-	ErrorOnToggleInputMute   error
-	ErrorOnSetInputVolume    error
-	ErrorOnGetInputVolume    error
+	ErrorOnConnect             error
+	ErrorOnGetSceneList        error
+	ErrorOnSetCurrentScene     error
+	ErrorOnCreateScene         error
+	ErrorOnRemoveScene         error
+	ErrorOnStartRecording      error
+	ErrorOnStopRecording       error
+	ErrorOnPauseRecording      error
+	ErrorOnResumeRecording     error
+	ErrorOnStartStreaming      error
+	ErrorOnStopStreaming       error
+	ErrorOnListSources         error
+	ErrorOnGetSourceSettings   error
+	ErrorOnToggleVisibility    error
+	ErrorOnGetInputMute        error
+	ErrorOnToggleInputMute     error
+	ErrorOnSetInputVolume      error
+	ErrorOnGetInputVolume      error
 	ErrorOnGetOBSStatus        error
 	ErrorOnCaptureSceneState   error
 	ErrorOnApplyScenePreset    error

--- a/internal/obs/commands.go
+++ b/internal/obs/commands.go
@@ -2,6 +2,7 @@ package obs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/andreykaipov/goobs/api/requests/inputs"
 	"github.com/andreykaipov/goobs/api/requests/sceneitems"
@@ -629,7 +630,14 @@ func (c *Client) TakeSourceScreenshot(opts ScreenshotOptions) (string, error) {
 		return "", fmt.Errorf("failed to capture screenshot of '%s': %w", opts.SourceName, err)
 	}
 
-	return resp.ImageData, nil
+	// OBS returns data as a data URI (e.g., "data:image/png;base64,iVBORw0...")
+	// Strip the prefix to return clean base64 data
+	imageData := resp.ImageData
+	if idx := strings.Index(imageData, ","); idx != -1 {
+		imageData = imageData[idx+1:]
+	}
+
+	return imageData, nil
 }
 
 // BrowserSourceSettings holds configuration for creating a browser source.

--- a/internal/screenshot/manager.go
+++ b/internal/screenshot/manager.go
@@ -1,0 +1,358 @@
+package screenshot
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ironystock/agentic-obs/internal/obs"
+	"github.com/ironystock/agentic-obs/internal/storage"
+)
+
+// OBSScreenshotter defines the interface for taking screenshots.
+// This allows the manager to work with both real and mock OBS clients.
+type OBSScreenshotter interface {
+	TakeSourceScreenshot(opts obs.ScreenshotOptions) (string, error)
+	IsConnected() bool
+}
+
+// Config holds screenshot manager configuration options.
+type Config struct {
+	// MaxScreenshotsPerSource is the maximum number of screenshots to keep per source.
+	// Older screenshots are automatically cleaned up. Default: 10
+	MaxScreenshotsPerSource int
+
+	// CleanupInterval is how often to run the cleanup routine. Default: 1 minute
+	CleanupInterval time.Duration
+}
+
+// DefaultConfig returns the default manager configuration.
+func DefaultConfig() Config {
+	return Config{
+		MaxScreenshotsPerSource: 10,
+		CleanupInterval:         time.Minute,
+	}
+}
+
+// Manager coordinates periodic screenshot capture from OBS sources.
+type Manager struct {
+	obsClient OBSScreenshotter
+	storage   *storage.DB
+	cfg       Config
+
+	mu      sync.RWMutex
+	workers map[int64]*worker
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	running bool
+}
+
+// NewManager creates a new screenshot manager.
+func NewManager(obsClient OBSScreenshotter, db *storage.DB, cfg Config) *Manager {
+	if cfg.MaxScreenshotsPerSource <= 0 {
+		cfg.MaxScreenshotsPerSource = 10
+	}
+	if cfg.CleanupInterval <= 0 {
+		cfg.CleanupInterval = time.Minute
+	}
+
+	return &Manager{
+		obsClient: obsClient,
+		storage:   db,
+		cfg:       cfg,
+		workers:   make(map[int64]*worker),
+	}
+}
+
+// Start initializes the manager, loads existing sources, and starts capture workers.
+func (m *Manager) Start(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.running {
+		return fmt.Errorf("screenshot manager already running")
+	}
+
+	m.ctx, m.cancel = context.WithCancel(ctx)
+	m.running = true
+
+	// Load all enabled screenshot sources and start workers
+	sources, err := m.storage.ListScreenshotSources(m.ctx)
+	if err != nil {
+		m.running = false
+		m.cancel()
+		return fmt.Errorf("failed to load screenshot sources: %w", err)
+	}
+
+	for _, source := range sources {
+		if source.Enabled {
+			if err := m.startWorkerLocked(source); err != nil {
+				// Log but continue - don't fail entirely for one bad source
+				continue
+			}
+		}
+	}
+
+	// Start cleanup goroutine
+	m.wg.Add(1)
+	go m.cleanupLoop()
+
+	return nil
+}
+
+// Stop gracefully shuts down all capture workers.
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	if !m.running {
+		m.mu.Unlock()
+		return
+	}
+	m.running = false
+	m.cancel()
+	m.mu.Unlock()
+
+	// Wait for all workers and cleanup goroutine to finish
+	m.wg.Wait()
+
+	// Clear workers map
+	m.mu.Lock()
+	m.workers = make(map[int64]*worker)
+	m.mu.Unlock()
+}
+
+// AddSource adds a new screenshot source and starts capturing if enabled.
+func (m *Manager) AddSource(source *storage.ScreenshotSource) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		return fmt.Errorf("screenshot manager not running")
+	}
+
+	if _, exists := m.workers[source.ID]; exists {
+		return fmt.Errorf("source %d already has a running worker", source.ID)
+	}
+
+	if source.Enabled {
+		return m.startWorkerLocked(source)
+	}
+
+	return nil
+}
+
+// RemoveSource stops and removes a screenshot source.
+func (m *Manager) RemoveSource(id int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if w, exists := m.workers[id]; exists {
+		w.stop()
+		delete(m.workers, id)
+	}
+
+	return nil
+}
+
+// UpdateSource updates a source's configuration and restarts its worker if needed.
+func (m *Manager) UpdateSource(source *storage.ScreenshotSource) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		return fmt.Errorf("screenshot manager not running")
+	}
+
+	// Stop existing worker if any
+	if w, exists := m.workers[source.ID]; exists {
+		w.stop()
+		delete(m.workers, source.ID)
+	}
+
+	// Start new worker if source is enabled
+	if source.Enabled {
+		return m.startWorkerLocked(source)
+	}
+
+	return nil
+}
+
+// UpdateCadence updates the capture interval for a source.
+func (m *Manager) UpdateCadence(id int64, cadenceMs int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		return fmt.Errorf("screenshot manager not running")
+	}
+
+	w, exists := m.workers[id]
+	if !exists {
+		return fmt.Errorf("no worker found for source %d", id)
+	}
+
+	w.updateCadence(time.Duration(cadenceMs) * time.Millisecond)
+	return nil
+}
+
+// GetWorkerCount returns the number of active workers.
+func (m *Manager) GetWorkerCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.workers)
+}
+
+// IsRunning returns whether the manager is currently running.
+func (m *Manager) IsRunning() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.running
+}
+
+// startWorkerLocked starts a worker for the given source.
+// Must be called with m.mu held.
+func (m *Manager) startWorkerLocked(source *storage.ScreenshotSource) error {
+	w := newWorker(m.ctx, m.obsClient, m.storage, source)
+	m.workers[source.ID] = w
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		w.run()
+	}()
+	return nil
+}
+
+// cleanupLoop periodically removes old screenshots to keep storage bounded.
+func (m *Manager) cleanupLoop() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.cfg.CleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.runCleanup()
+		}
+	}
+}
+
+// runCleanup removes old screenshots for all sources.
+func (m *Manager) runCleanup() {
+	sources, err := m.storage.ListScreenshotSources(m.ctx)
+	if err != nil {
+		return
+	}
+
+	for _, source := range sources {
+		m.storage.DeleteOldScreenshots(m.ctx, source.ID, m.cfg.MaxScreenshotsPerSource)
+	}
+}
+
+// worker handles periodic capture for a single screenshot source.
+type worker struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	obsClient OBSScreenshotter
+	storage   *storage.DB
+	source    *storage.ScreenshotSource
+
+	mu      sync.RWMutex
+	cadence time.Duration
+}
+
+// newWorker creates a new capture worker for a source.
+func newWorker(parentCtx context.Context, obs OBSScreenshotter, db *storage.DB, source *storage.ScreenshotSource) *worker {
+	ctx, cancel := context.WithCancel(parentCtx)
+	return &worker{
+		ctx:       ctx,
+		cancel:    cancel,
+		obsClient: obs,
+		storage:   db,
+		source:    source,
+		cadence:   time.Duration(source.CadenceMs) * time.Millisecond,
+	}
+}
+
+// run starts the capture loop.
+func (w *worker) run() {
+	// Capture immediately on start
+	w.capture()
+
+	ticker := time.NewTicker(w.getCadence())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case <-ticker.C:
+			w.capture()
+			// Check if cadence changed
+			newCadence := w.getCadence()
+			if ticker.Reset(newCadence); newCadence != w.getCadence() {
+				ticker.Reset(w.getCadence())
+			}
+		}
+	}
+}
+
+// stop cancels the worker's context.
+func (w *worker) stop() {
+	w.cancel()
+}
+
+// updateCadence changes the capture interval.
+func (w *worker) updateCadence(cadence time.Duration) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.cadence = cadence
+}
+
+// getCadence returns the current capture interval.
+func (w *worker) getCadence() time.Duration {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.cadence
+}
+
+// capture takes a screenshot and saves it to storage.
+func (w *worker) capture() {
+	if !w.obsClient.IsConnected() {
+		return
+	}
+
+	opts := obs.ScreenshotOptions{
+		SourceName: w.source.SourceName,
+		Format:     w.source.ImageFormat,
+		Width:      w.source.ImageWidth,
+		Height:     w.source.ImageHeight,
+		Quality:    w.source.Quality,
+	}
+
+	imageData, err := w.obsClient.TakeSourceScreenshot(opts)
+	if err != nil {
+		return
+	}
+
+	// Determine MIME type
+	mimeType := "image/png"
+	if w.source.ImageFormat == "jpg" || w.source.ImageFormat == "jpeg" {
+		mimeType = "image/jpeg"
+	}
+
+	// Calculate approximate size (base64 is ~4/3 of original)
+	sizeBytes := len(imageData) * 3 / 4
+
+	screenshot := storage.Screenshot{
+		SourceID:  w.source.ID,
+		ImageData: imageData,
+		MimeType:  mimeType,
+		SizeBytes: sizeBytes,
+	}
+
+	w.storage.SaveScreenshot(w.ctx, screenshot)
+}

--- a/internal/storage/screenshots.go
+++ b/internal/storage/screenshots.go
@@ -1,0 +1,339 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// ScreenshotSource represents a configured screenshot capture source.
+// Sources define which OBS scene/source to capture and at what interval.
+type ScreenshotSource struct {
+	ID          int64     `json:"id"`
+	Name        string    `json:"name"`         // User-friendly unique name
+	SourceName  string    `json:"source_name"`  // OBS scene or source name to capture
+	CadenceMs   int       `json:"cadence_ms"`   // Capture interval in milliseconds
+	ImageFormat string    `json:"image_format"` // "png" or "jpg"
+	ImageWidth  int       `json:"image_width"`  // Optional resize width (0 = original)
+	ImageHeight int       `json:"image_height"` // Optional resize height (0 = original)
+	Quality     int       `json:"quality"`      // Compression quality 0-100
+	Enabled     bool      `json:"enabled"`      // Whether capture is active
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Screenshot represents a captured screenshot image.
+type Screenshot struct {
+	ID         int64     `json:"id"`
+	SourceID   int64     `json:"source_id"`   // FK to ScreenshotSource
+	ImageData  string    `json:"image_data"`  // Base64-encoded image data
+	MimeType   string    `json:"mime_type"`   // "image/png" or "image/jpeg"
+	CapturedAt time.Time `json:"captured_at"`
+	SizeBytes  int       `json:"size_bytes"`
+}
+
+// CreateScreenshotSource creates a new screenshot source in the database.
+// Returns the ID of the newly created source.
+func (db *DB) CreateScreenshotSource(ctx context.Context, source ScreenshotSource) (int64, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	// Set defaults
+	if source.CadenceMs <= 0 {
+		source.CadenceMs = 5000
+	}
+	if source.ImageFormat == "" {
+		source.ImageFormat = "png"
+	}
+	if source.Quality <= 0 {
+		source.Quality = 80
+	}
+
+	result, err := db.conn.ExecContext(ctx, `
+		INSERT INTO screenshot_sources (name, source_name, cadence_ms, image_format, image_width, image_height, quality, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, source.Name, source.SourceName, source.CadenceMs, source.ImageFormat, source.ImageWidth, source.ImageHeight, source.Quality, source.Enabled)
+
+	if err != nil {
+		// Check for unique constraint violation
+		if err.Error() == "UNIQUE constraint failed: screenshot_sources.name" {
+			return 0, fmt.Errorf("screenshot source with name '%s' already exists", source.Name)
+		}
+		return 0, fmt.Errorf("failed to create screenshot source: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get inserted source ID: %w", err)
+	}
+
+	return id, nil
+}
+
+// GetScreenshotSource retrieves a screenshot source by ID.
+func (db *DB) GetScreenshotSource(ctx context.Context, id int64) (*ScreenshotSource, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	var source ScreenshotSource
+	var createdAt, updatedAt string
+	var imageWidth, imageHeight sql.NullInt64
+
+	err := db.conn.QueryRowContext(ctx, `
+		SELECT id, name, source_name, cadence_ms, image_format, image_width, image_height, quality, enabled, created_at, updated_at
+		FROM screenshot_sources
+		WHERE id = ?
+	`, id).Scan(&source.ID, &source.Name, &source.SourceName, &source.CadenceMs, &source.ImageFormat,
+		&imageWidth, &imageHeight, &source.Quality, &source.Enabled, &createdAt, &updatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("screenshot source with ID %d not found", id)
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get screenshot source with ID %d: %w", id, err)
+	}
+
+	// Handle nullable width/height
+	if imageWidth.Valid {
+		source.ImageWidth = int(imageWidth.Int64)
+	}
+	if imageHeight.Valid {
+		source.ImageHeight = int(imageHeight.Int64)
+	}
+
+	// Parse timestamps
+	source.CreatedAt, _ = parseTimestamp(createdAt)
+	source.UpdatedAt, _ = parseTimestamp(updatedAt)
+
+	return &source, nil
+}
+
+// GetScreenshotSourceByName retrieves a screenshot source by name.
+func (db *DB) GetScreenshotSourceByName(ctx context.Context, name string) (*ScreenshotSource, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	var source ScreenshotSource
+	var createdAt, updatedAt string
+	var imageWidth, imageHeight sql.NullInt64
+
+	err := db.conn.QueryRowContext(ctx, `
+		SELECT id, name, source_name, cadence_ms, image_format, image_width, image_height, quality, enabled, created_at, updated_at
+		FROM screenshot_sources
+		WHERE name = ?
+	`, name).Scan(&source.ID, &source.Name, &source.SourceName, &source.CadenceMs, &source.ImageFormat,
+		&imageWidth, &imageHeight, &source.Quality, &source.Enabled, &createdAt, &updatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("screenshot source '%s' not found", name)
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get screenshot source '%s': %w", name, err)
+	}
+
+	// Handle nullable width/height
+	if imageWidth.Valid {
+		source.ImageWidth = int(imageWidth.Int64)
+	}
+	if imageHeight.Valid {
+		source.ImageHeight = int(imageHeight.Int64)
+	}
+
+	// Parse timestamps
+	source.CreatedAt, _ = parseTimestamp(createdAt)
+	source.UpdatedAt, _ = parseTimestamp(updatedAt)
+
+	return &source, nil
+}
+
+// ListScreenshotSources retrieves all screenshot sources.
+func (db *DB) ListScreenshotSources(ctx context.Context) ([]*ScreenshotSource, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	rows, err := db.conn.QueryContext(ctx, `
+		SELECT id, name, source_name, cadence_ms, image_format, image_width, image_height, quality, enabled, created_at, updated_at
+		FROM screenshot_sources
+		ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list screenshot sources: %w", err)
+	}
+	defer rows.Close()
+
+	var sources []*ScreenshotSource
+	for rows.Next() {
+		var source ScreenshotSource
+		var createdAt, updatedAt string
+		var imageWidth, imageHeight sql.NullInt64
+
+		if err := rows.Scan(&source.ID, &source.Name, &source.SourceName, &source.CadenceMs, &source.ImageFormat,
+			&imageWidth, &imageHeight, &source.Quality, &source.Enabled, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan screenshot source row: %w", err)
+		}
+
+		// Handle nullable width/height
+		if imageWidth.Valid {
+			source.ImageWidth = int(imageWidth.Int64)
+		}
+		if imageHeight.Valid {
+			source.ImageHeight = int(imageHeight.Int64)
+		}
+
+		// Parse timestamps
+		source.CreatedAt, _ = parseTimestamp(createdAt)
+		source.UpdatedAt, _ = parseTimestamp(updatedAt)
+
+		sources = append(sources, &source)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating screenshot sources: %w", err)
+	}
+
+	return sources, nil
+}
+
+// UpdateScreenshotSource updates an existing screenshot source.
+func (db *DB) UpdateScreenshotSource(ctx context.Context, source ScreenshotSource) error {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	result, err := db.conn.ExecContext(ctx, `
+		UPDATE screenshot_sources
+		SET source_name = ?, cadence_ms = ?, image_format = ?, image_width = ?, image_height = ?, quality = ?, enabled = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, source.SourceName, source.CadenceMs, source.ImageFormat, source.ImageWidth, source.ImageHeight, source.Quality, source.Enabled, source.ID)
+
+	if err != nil {
+		return fmt.Errorf("failed to update screenshot source: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("screenshot source with ID %d not found", source.ID)
+	}
+
+	return nil
+}
+
+// DeleteScreenshotSource deletes a screenshot source and all its screenshots (via CASCADE).
+func (db *DB) DeleteScreenshotSource(ctx context.Context, id int64) error {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	result, err := db.conn.ExecContext(ctx, `DELETE FROM screenshot_sources WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete screenshot source: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("screenshot source with ID %d not found", id)
+	}
+
+	return nil
+}
+
+// SaveScreenshot saves a captured screenshot to the database.
+// Returns the ID of the newly created screenshot.
+func (db *DB) SaveScreenshot(ctx context.Context, screenshot Screenshot) (int64, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	result, err := db.conn.ExecContext(ctx, `
+		INSERT INTO screenshots (source_id, image_data, mime_type, captured_at, size_bytes)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)
+	`, screenshot.SourceID, screenshot.ImageData, screenshot.MimeType, screenshot.SizeBytes)
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to save screenshot: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get inserted screenshot ID: %w", err)
+	}
+
+	return id, nil
+}
+
+// GetLatestScreenshot retrieves the most recent screenshot for a source.
+func (db *DB) GetLatestScreenshot(ctx context.Context, sourceID int64) (*Screenshot, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	var screenshot Screenshot
+	var capturedAt string
+
+	err := db.conn.QueryRowContext(ctx, `
+		SELECT id, source_id, image_data, mime_type, captured_at, size_bytes
+		FROM screenshots
+		WHERE source_id = ?
+		ORDER BY captured_at DESC
+		LIMIT 1
+	`, sourceID).Scan(&screenshot.ID, &screenshot.SourceID, &screenshot.ImageData, &screenshot.MimeType, &capturedAt, &screenshot.SizeBytes)
+
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("no screenshots found for source ID %d", sourceID)
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get latest screenshot for source ID %d: %w", sourceID, err)
+	}
+
+	screenshot.CapturedAt, _ = parseTimestamp(capturedAt)
+
+	return &screenshot, nil
+}
+
+// DeleteOldScreenshots deletes old screenshots, keeping only the most recent keepCount.
+// Returns the number of deleted screenshots.
+func (db *DB) DeleteOldScreenshots(ctx context.Context, sourceID int64, keepCount int) (int64, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	// Delete screenshots older than the Nth most recent
+	result, err := db.conn.ExecContext(ctx, `
+		DELETE FROM screenshots
+		WHERE source_id = ? AND id NOT IN (
+			SELECT id FROM screenshots
+			WHERE source_id = ?
+			ORDER BY captured_at DESC
+			LIMIT ?
+		)
+	`, sourceID, sourceID, keepCount)
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete old screenshots: %w", err)
+	}
+
+	rowsDeleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows deleted: %w", err)
+	}
+
+	return rowsDeleted, nil
+}
+
+// CountScreenshots returns the number of screenshots for a source.
+func (db *DB) CountScreenshots(ctx context.Context, sourceID int64) (int64, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	var count int64
+	err := db.conn.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM screenshots WHERE source_id = ?
+	`, sourceID).Scan(&count)
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to count screenshots: %w", err)
+	}
+
+	return count, nil
+}

--- a/internal/storage/screenshots.go
+++ b/internal/storage/screenshots.go
@@ -26,9 +26,9 @@ type ScreenshotSource struct {
 // Screenshot represents a captured screenshot image.
 type Screenshot struct {
 	ID         int64     `json:"id"`
-	SourceID   int64     `json:"source_id"`   // FK to ScreenshotSource
-	ImageData  string    `json:"image_data"`  // Base64-encoded image data
-	MimeType   string    `json:"mime_type"`   // "image/png" or "image/jpeg"
+	SourceID   int64     `json:"source_id"`  // FK to ScreenshotSource
+	ImageData  string    `json:"image_data"` // Base64-encoded image data
+	MimeType   string    `json:"mime_type"`  // "image/png" or "image/jpeg"
 	CapturedAt time.Time `json:"captured_at"`
 	SizeBytes  int       `json:"size_bytes"`
 }

--- a/internal/storage/screenshots_test.go
+++ b/internal/storage/screenshots_test.go
@@ -1,0 +1,434 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupScreenshotTestDB(t *testing.T) (*DB, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "screenshot_test_*")
+	require.NoError(t, err)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := New(context.Background(), Config{Path: dbPath})
+	require.NoError(t, err)
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	}
+
+	return db, cleanup
+}
+
+func TestCreateScreenshotSource(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("creates source with all fields", func(t *testing.T) {
+		source := ScreenshotSource{
+			Name:        "test-source",
+			SourceName:  "Scene 1",
+			CadenceMs:   3000,
+			ImageFormat: "jpg",
+			ImageWidth:  1920,
+			ImageHeight: 1080,
+			Quality:     90,
+			Enabled:     true,
+		}
+
+		id, err := db.CreateScreenshotSource(ctx, source)
+		require.NoError(t, err)
+		assert.Greater(t, id, int64(0))
+
+		// Verify the source was created
+		got, err := db.GetScreenshotSource(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, "test-source", got.Name)
+		assert.Equal(t, "Scene 1", got.SourceName)
+		assert.Equal(t, 3000, got.CadenceMs)
+		assert.Equal(t, "jpg", got.ImageFormat)
+		assert.Equal(t, 1920, got.ImageWidth)
+		assert.Equal(t, 1080, got.ImageHeight)
+		assert.Equal(t, 90, got.Quality)
+		assert.True(t, got.Enabled)
+	})
+
+	t.Run("applies defaults for missing values", func(t *testing.T) {
+		source := ScreenshotSource{
+			Name:       "default-source",
+			SourceName: "Scene 2",
+			Enabled:    true,
+		}
+
+		id, err := db.CreateScreenshotSource(ctx, source)
+		require.NoError(t, err)
+
+		got, err := db.GetScreenshotSource(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, 5000, got.CadenceMs)   // Default
+		assert.Equal(t, "png", got.ImageFormat) // Default
+		assert.Equal(t, 80, got.Quality)        // Default
+	})
+
+	t.Run("rejects duplicate names", func(t *testing.T) {
+		source := ScreenshotSource{
+			Name:       "unique-name",
+			SourceName: "Scene 3",
+			Enabled:    true,
+		}
+
+		_, err := db.CreateScreenshotSource(ctx, source)
+		require.NoError(t, err)
+
+		// Try to create another with the same name
+		_, err = db.CreateScreenshotSource(ctx, source)
+		assert.Error(t, err)
+		// Error message may vary by SQLite driver
+		assert.True(t, err != nil, "expected an error for duplicate name")
+	})
+}
+
+func TestGetScreenshotSource(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("returns error for non-existent ID", func(t *testing.T) {
+		_, err := db.GetScreenshotSource(ctx, 99999)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestGetScreenshotSourceByName(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	source := ScreenshotSource{
+		Name:       "named-source",
+		SourceName: "Gaming Scene",
+		Enabled:    true,
+	}
+
+	id, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	t.Run("finds source by name", func(t *testing.T) {
+		got, err := db.GetScreenshotSourceByName(ctx, "named-source")
+		require.NoError(t, err)
+		assert.Equal(t, id, got.ID)
+		assert.Equal(t, "Gaming Scene", got.SourceName)
+	})
+
+	t.Run("returns error for non-existent name", func(t *testing.T) {
+		_, err := db.GetScreenshotSourceByName(ctx, "nonexistent")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestListScreenshotSources(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("returns empty list initially", func(t *testing.T) {
+		sources, err := db.ListScreenshotSources(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, sources)
+	})
+
+	t.Run("returns all created sources", func(t *testing.T) {
+		for i := 0; i < 3; i++ {
+			source := ScreenshotSource{
+				Name:       "source-" + string(rune('a'+i)),
+				SourceName: "Scene " + string(rune('1'+i)),
+				Enabled:    true,
+			}
+			_, err := db.CreateScreenshotSource(ctx, source)
+			require.NoError(t, err)
+		}
+
+		sources, err := db.ListScreenshotSources(ctx)
+		require.NoError(t, err)
+		assert.Len(t, sources, 3)
+	})
+}
+
+func TestUpdateScreenshotSource(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	source := ScreenshotSource{
+		Name:       "update-test",
+		SourceName: "Original Scene",
+		CadenceMs:  5000,
+		Quality:    80,
+		Enabled:    true,
+	}
+
+	id, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	t.Run("updates source fields", func(t *testing.T) {
+		updated := ScreenshotSource{
+			ID:          id,
+			SourceName:  "Updated Scene",
+			CadenceMs:   10000,
+			ImageFormat: "jpg",
+			Quality:     50,
+			Enabled:     false,
+		}
+
+		err := db.UpdateScreenshotSource(ctx, updated)
+		require.NoError(t, err)
+
+		got, err := db.GetScreenshotSource(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Scene", got.SourceName)
+		assert.Equal(t, 10000, got.CadenceMs)
+		assert.Equal(t, "jpg", got.ImageFormat)
+		assert.Equal(t, 50, got.Quality)
+		assert.False(t, got.Enabled)
+	})
+
+	t.Run("returns error for non-existent ID", func(t *testing.T) {
+		updated := ScreenshotSource{
+			ID:         99999,
+			SourceName: "Test",
+		}
+
+		err := db.UpdateScreenshotSource(ctx, updated)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeleteScreenshotSource(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	source := ScreenshotSource{
+		Name:       "delete-test",
+		SourceName: "Scene to Delete",
+		Enabled:    true,
+	}
+
+	id, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	t.Run("deletes existing source", func(t *testing.T) {
+		err := db.DeleteScreenshotSource(ctx, id)
+		require.NoError(t, err)
+
+		// Verify it's gone
+		_, err = db.GetScreenshotSource(ctx, id)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error for non-existent ID", func(t *testing.T) {
+		err := db.DeleteScreenshotSource(ctx, 99999)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestSaveScreenshot(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Create a source first
+	source := ScreenshotSource{
+		Name:       "screenshot-source",
+		SourceName: "Test Scene",
+		Enabled:    true,
+	}
+	sourceID, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	t.Run("saves screenshot successfully", func(t *testing.T) {
+		screenshot := Screenshot{
+			SourceID:  sourceID,
+			ImageData: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+			MimeType:  "image/png",
+			SizeBytes: 100,
+		}
+
+		id, err := db.SaveScreenshot(ctx, screenshot)
+		require.NoError(t, err)
+		assert.Greater(t, id, int64(0))
+	})
+}
+
+func TestGetLatestScreenshot(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Create a source
+	source := ScreenshotSource{
+		Name:       "latest-source",
+		SourceName: "Test Scene",
+		Enabled:    true,
+	}
+	sourceID, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	t.Run("returns error when no screenshots exist", func(t *testing.T) {
+		_, err := db.GetLatestScreenshot(ctx, sourceID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no screenshots found")
+	})
+
+	t.Run("returns a screenshot after saving", func(t *testing.T) {
+		// Save a screenshot
+		screenshot := Screenshot{
+			SourceID:  sourceID,
+			ImageData: "test-image-data",
+			MimeType:  "image/png",
+			SizeBytes: 150,
+		}
+		_, err := db.SaveScreenshot(ctx, screenshot)
+		require.NoError(t, err)
+
+		got, err := db.GetLatestScreenshot(ctx, sourceID)
+		require.NoError(t, err)
+		assert.Equal(t, "test-image-data", got.ImageData)
+		assert.Equal(t, "image/png", got.MimeType)
+		assert.Equal(t, 150, got.SizeBytes)
+		assert.Equal(t, sourceID, got.SourceID)
+	})
+}
+
+func TestDeleteOldScreenshots(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Create a source
+	source := ScreenshotSource{
+		Name:       "cleanup-source",
+		SourceName: "Test Scene",
+		Enabled:    true,
+	}
+	sourceID, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	// Save 10 screenshots
+	for i := 0; i < 10; i++ {
+		screenshot := Screenshot{
+			SourceID:  sourceID,
+			ImageData: "data" + string(rune('0'+i)),
+			MimeType:  "image/png",
+			SizeBytes: 100,
+		}
+		_, err := db.SaveScreenshot(ctx, screenshot)
+		require.NoError(t, err)
+	}
+
+	t.Run("keeps only specified count", func(t *testing.T) {
+		count, err := db.CountScreenshots(ctx, sourceID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(10), count)
+
+		// Keep only 3
+		deleted, err := db.DeleteOldScreenshots(ctx, sourceID, 3)
+		require.NoError(t, err)
+		assert.Equal(t, int64(7), deleted)
+
+		count, err = db.CountScreenshots(ctx, sourceID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), count)
+	})
+}
+
+func TestCountScreenshots(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Create a source
+	source := ScreenshotSource{
+		Name:       "count-source",
+		SourceName: "Test Scene",
+		Enabled:    true,
+	}
+	sourceID, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	t.Run("returns zero for empty source", func(t *testing.T) {
+		count, err := db.CountScreenshots(ctx, sourceID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("counts screenshots correctly", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			screenshot := Screenshot{
+				SourceID:  sourceID,
+				ImageData: "test",
+				MimeType:  "image/png",
+				SizeBytes: 100,
+			}
+			_, err := db.SaveScreenshot(ctx, screenshot)
+			require.NoError(t, err)
+		}
+
+		count, err := db.CountScreenshots(ctx, sourceID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), count)
+	})
+}
+
+func TestCascadeDeleteScreenshots(t *testing.T) {
+	db, cleanup := setupScreenshotTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Create a source
+	source := ScreenshotSource{
+		Name:       "cascade-source",
+		SourceName: "Test Scene",
+		Enabled:    true,
+	}
+	sourceID, err := db.CreateScreenshotSource(ctx, source)
+	require.NoError(t, err)
+
+	// Save screenshots
+	for i := 0; i < 5; i++ {
+		screenshot := Screenshot{
+			SourceID:  sourceID,
+			ImageData: "test",
+			MimeType:  "image/png",
+			SizeBytes: 100,
+		}
+		_, err := db.SaveScreenshot(ctx, screenshot)
+		require.NoError(t, err)
+	}
+
+	// Verify screenshots exist
+	count, err := db.CountScreenshots(ctx, sourceID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+
+	// Delete the source
+	err = db.DeleteScreenshotSource(ctx, sourceID)
+	require.NoError(t, err)
+
+	// Screenshots should be deleted via CASCADE
+	count, err = db.CountScreenshots(ctx, sourceID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}

--- a/internal/storage/screenshots_test.go
+++ b/internal/storage/screenshots_test.go
@@ -73,7 +73,7 @@ func TestCreateScreenshotSource(t *testing.T) {
 
 		got, err := db.GetScreenshotSource(ctx, id)
 		require.NoError(t, err)
-		assert.Equal(t, 5000, got.CadenceMs)   // Default
+		assert.Equal(t, 5000, got.CadenceMs)    // Default
 		assert.Equal(t, "png", got.ImageFormat) // Default
 		assert.Equal(t, 80, got.Quality)        // Default
 	})


### PR DESCRIPTION
## Summary
- Add 4 new MCP tools for screenshot source management enabling AI visual monitoring of OBS streams
- Implement HTTP server for serving screenshots at `localhost:8765/screenshot/{name}`
- Add background capture manager with configurable cadence per source
- Automatic cleanup keeps storage bounded (10 screenshots per source default)

## New Tools
| Tool | Description |
|------|-------------|
| `create_screenshot_source` | Create periodic capture for an OBS scene/source |
| `remove_screenshot_source` | Stop and remove a screenshot source |
| `list_screenshot_sources` | List sources with status and HTTP URLs |
| `configure_screenshot_cadence` | Update capture interval |

## Architecture
```
AI Assistant --> MCP Tools --> Screenshot Manager --> OBS (capture)
                                     |
                                     v
                               SQLite (storage)
                                     |
                                     v
AI Assistant <-- HTTP Server <-- /screenshot/{name}
```

## Files Changed
**New:**
- `internal/http/server.go` - HTTP server for image serving
- `internal/screenshot/manager.go` - Background capture coordination
- `internal/storage/screenshots.go` - Screenshot source/image persistence
- `internal/storage/screenshots_test.go` - Storage tests

**Modified:**
- `internal/storage/db.go` - Migrations 8-10 for screenshot tables
- `internal/obs/commands.go` - TakeSourceScreenshot, CreateBrowserSource
- `internal/mcp/server.go` - HTTP server and manager integration
- `internal/mcp/tools.go` - 4 new tool handlers
- `internal/mcp/interfaces.go` - New methods in OBSClient
- `internal/mcp/testutil/mock_obs.go` - Mock implementations
- `CLAUDE.md`, `README.md` - Documentation updates

## Test plan
- [x] All existing tests pass
- [x] New screenshot storage tests pass (12 test cases)
- [x] Code compiles with `go build ./...`
- [ ] Manual testing with OBS (requires OBS Studio running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)