### PR TITLE
Phase D: MCP Resources & Prompts Enhancement

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -104,6 +104,9 @@ go install
 MCP Client (Claude/AI Agent)
     ↕ stdio (JSON-RPC)
 MCP Server (this project)
+    ├─ Tools (30 total)
+    ├─ Resources (scenes, screenshots, presets)
+    ├─ Prompts (10 workflows)
     ↕ WebSocket (port 4455)
 OBS Studio (obs-websocket)
     ↕ SQLite (local)
@@ -130,19 +133,32 @@ Configuration & Presets
 
 ### MCP Resources
 
-**OBS Scenes** are exposed as MCP resources with the following structure:
+The server exposes three types of MCP resources for client access:
 
-- **Resource URI Pattern**: `obs://scene_{scene_name}`
+**1. OBS Scenes** - Scene configurations and source layouts
+- **Resource URI Pattern**: `obs://scene/{sceneName}`
 - **Resource Type**: `obs-scene`
 - **Content**: JSON representation of scene configuration (sources, settings)
 - **Notifications**:
   - `notifications/resources/list_changed` - When scenes are created/deleted
   - `notifications/resources/updated` - When a specific scene is modified or becomes active
 
+**2. Screenshot Images** - Binary screenshot data
+- **Resource URI Pattern**: `obs://screenshot/{sourceName}`
+- **Resource Type**: `image/png` or `image/jpeg`
+- **Content**: Binary image data (PNG or JPEG format)
+- **Description**: Direct access to screenshot images as MCP resources
+
+**3. Scene Presets** - Saved source visibility configurations
+- **Resource URI Pattern**: `obs://preset/{presetName}`
+- **Resource Type**: `obs-preset`
+- **Content**: JSON representation of preset configuration (scene, sources, visibility states)
+- **Description**: Access to saved scene preset configurations
+
 **Resource Operations:**
-- `resources/list` - List all available scenes
-- `resources/read` - Get detailed scene configuration
-- `resources/subscribe` - Subscribe to scene change notifications (future)
+- `resources/list` - List all available resources of all types
+- `resources/read` - Get detailed resource content (JSON or binary)
+- `resources/subscribe` - Subscribe to resource change notifications (future)
 
 ### MCP Tools Implemented (30 tools)
 
@@ -157,6 +173,30 @@ Core tools for OBS control:
 - **Status**: `get_obs_status` (overall OBS connection and state)
 
 **Note:** Scenes are also exposed as MCP resources (`resources/list`), enabling notification support.
+
+### MCP Prompts Implemented (10 prompts)
+
+Pre-built prompts for common OBS workflows and tasks:
+
+| Prompt | Arguments | Description |
+|--------|-----------|-------------|
+| `stream-launch` | none | Pre-stream checklist and setup guidance |
+| `stream-teardown` | none | End-stream cleanup and shutdown workflow |
+| `audio-check` | none | Audio verification and diagnostics |
+| `visual-check` | screenshot_source (required) | Visual layout analysis using screenshot sources |
+| `health-check` | none | Comprehensive OBS diagnostic and status check |
+| `problem-detection` | screenshot_source (required) | Automated issue detection from visual monitoring |
+| `preset-switcher` | preset_name (optional) | Scene preset management and switching |
+| `recording-workflow` | none | Complete recording session management |
+| `scene-organizer` | none | Scene organization and cleanup guidance |
+| `quick-status` | none | Brief status summary for rapid checks |
+
+**Prompts enhance the AI assistant's capability to:**
+- Guide users through complex multi-step workflows
+- Provide context-aware recommendations
+- Automate common tasks with best practices built-in
+- Offer structured checklists and verification steps
+- Combine multiple tools into cohesive operations
 
 ## Important Context for AI Assistants
 
@@ -191,11 +231,19 @@ Core tools for OBS control:
 - Background capture manager with configurable cadence
 - Automatic cleanup to keep storage bounded
 
+**Phase 4 (Complete):**
+- MCP Resources expansion: 3 resource types (scenes, screenshots, presets)
+- MCP Prompts: 10 workflow prompts for common tasks
+- Screenshots and presets exposed as MCP resources
+- Resource URIs: `obs://scene/{name}`, `obs://screenshot/{name}`, `obs://preset/{name}`
+- Workflow prompts for streaming, recording, diagnostics, and management
+
 **Future Enhancements:**
 - Multi-instance OBS support (requires architecture refactor)
 - Additional resource types (sources, filters, transitions)
 - Automation rules and macros
 - Interactive setup (TUI and web interface)
+- Resource subscriptions (explicit client opt-in to notifications)
 
 ### Testing
 
@@ -233,8 +281,9 @@ go mod tidy
 ### Areas Needing Attention
 
 **TODO - Future Enhancements:**
-- [x] **Agentic Screenshot Sources** (Phase C): Enable AI to "see" stream via periodic screenshot capture with HTTP serving ✓
-- [ ] Automation rules and macros (Phase D): Event-triggered actions and multi-step sequences
+- [x] **Agentic Screenshot Sources** (Phase 3): Enable AI to "see" stream via periodic screenshot capture with HTTP serving ✓
+- [x] **MCP Resources & Prompts** (Phase 4): Expand resources and add workflow prompts ✓
+- [ ] Automation rules and macros (Phase 5): Event-triggered actions and multi-step sequences
 - [ ] Multi-target OBS support (architecture decision needed)
 - [ ] Interactive installation UX (TUI + Web)
 - [ ] Health check and monitoring endpoints

--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ This MCP server provides AI agents (like Claude) with programmatic control over 
 
 ## Features
 
+- **30 MCP Tools**: Comprehensive control over OBS Studio operations
 - **Scene Management**: List, switch, create, and remove OBS scenes
 - **Scene Presets**: Save and restore source visibility configurations
 - **Recording Control**: Start, stop, pause, resume, and monitor recording
 - **Streaming Control**: Start, stop, and monitor streaming
 - **Source Management**: List and control source visibility
 - **Audio Control**: Manage input mute and volume levels
+- **Screenshot Sources**: AI visual monitoring with periodic image capture
 - **Status Monitoring**: Query OBS connection and operational status
+- **3 MCP Resources**: Scenes, screenshots, and presets exposed as resources
+- **10 MCP Prompts**: Pre-built workflows for common tasks and diagnostics
 
 ## Prerequisites
 
@@ -174,6 +178,40 @@ Example Claude Desktop configuration (`claude_desktop_config.json`):
 | `get_obs_status` | Get overall OBS status and connection info |
 
 **Total: 30 tools**
+
+## MCP Resources
+
+The server exposes OBS data as MCP resources for efficient access and monitoring:
+
+| Resource Type | URI Pattern | Content Type | Description |
+|---------------|-------------|--------------|-------------|
+| Scenes | `obs://scene/{name}` | `obs-scene` (JSON) | Scene configuration with sources and settings |
+| Screenshots | `obs://screenshot/{name}` | `image/png` or `image/jpeg` | Binary screenshot images from capture sources |
+| Presets | `obs://preset/{name}` | `obs-preset` (JSON) | Scene preset configurations with source visibility |
+
+**Usage:**
+- `resources/list` - List all available resources
+- `resources/read` - Get detailed resource content
+- Resources support notifications for real-time updates
+
+## MCP Prompts
+
+Pre-built workflow prompts guide AI assistants through common OBS tasks:
+
+| Prompt | Arguments | Purpose |
+|--------|-----------|---------|
+| `stream-launch` | none | Pre-stream checklist and setup |
+| `stream-teardown` | none | End-stream cleanup workflow |
+| `audio-check` | none | Audio verification and diagnostics |
+| `visual-check` | screenshot_source | Visual layout analysis |
+| `health-check` | none | Comprehensive OBS diagnostics |
+| `problem-detection` | screenshot_source | Automated issue detection |
+| `preset-switcher` | preset_name (optional) | Scene preset management |
+| `recording-workflow` | none | Recording session guidance |
+| `scene-organizer` | none | Scene organization and cleanup |
+| `quick-status` | none | Brief status summary |
+
+Prompts combine multiple tools into cohesive workflows with best practices built-in.
 
 ## Development
 

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -261,8 +261,10 @@ func (s *Server) handleVisualCheck(ctx context.Context, req *mcpsdk.GetPromptReq
 	log.Println("Handling visual-check prompt")
 
 	screenshotSource := ""
-	if val, ok := req.Params.Arguments["screenshot_source"]; ok {
-		screenshotSource = val
+	if req != nil && req.Params.Arguments != nil {
+		if val, ok := req.Params.Arguments["screenshot_source"]; ok {
+			screenshotSource = val
+		}
 	}
 
 	if screenshotSource == "" {
@@ -375,8 +377,10 @@ func (s *Server) handleProblemDetection(ctx context.Context, req *mcpsdk.GetProm
 	log.Println("Handling problem-detection prompt")
 
 	screenshotSource := ""
-	if val, ok := req.Params.Arguments["screenshot_source"]; ok {
-		screenshotSource = val
+	if req != nil && req.Params.Arguments != nil {
+		if val, ok := req.Params.Arguments["screenshot_source"]; ok {
+			screenshotSource = val
+		}
 	}
 
 	if screenshotSource == "" {
@@ -440,8 +444,10 @@ func (s *Server) handlePresetSwitcher(ctx context.Context, req *mcpsdk.GetPrompt
 	log.Println("Handling preset-switcher prompt")
 
 	presetName := ""
-	if val, ok := req.Params.Arguments["preset_name"]; ok {
-		presetName = val
+	if req != nil && req.Params.Arguments != nil {
+		if val, ok := req.Params.Arguments["preset_name"]; ok {
+			presetName = val
+		}
 	}
 
 	promptText := `Help me manage scene presets for quick configuration switching:

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,645 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerPrompts registers all MCP prompt handlers with the server
+func (s *Server) registerPrompts() {
+	// Prompt 1: Stream Launch Checklist
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "stream-launch",
+			Description: "Pre-stream checklist to verify OBS is ready for streaming",
+		},
+		s.handleStreamLaunch,
+	)
+
+	// Prompt 2: Stream Teardown
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "stream-teardown",
+			Description: "Post-stream cleanup to stop streaming/recording and switch to offline scene",
+		},
+		s.handleStreamTeardown,
+	)
+
+	// Prompt 3: Audio Check
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "audio-check",
+			Description: "Verify all audio inputs are configured correctly with proper mute states and volumes",
+		},
+		s.handleAudioCheck,
+	)
+
+	// Prompt 4: Visual Check
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "visual-check",
+			Description: "Analyze a screenshot to verify the stream layout and identify any visual issues",
+			Arguments: []*mcpsdk.PromptArgument{{
+				Name:        "screenshot_source",
+				Description: "Name of the screenshot source to analyze",
+				Required:    true,
+			}},
+		},
+		s.handleVisualCheck,
+	)
+
+	// Prompt 5: Health Check
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "health-check",
+			Description: "Run a comprehensive diagnostic of OBS connection, scenes, sources, and streaming state",
+		},
+		s.handleHealthCheck,
+	)
+
+	// Prompt 6: Problem Detection
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "problem-detection",
+			Description: "Detect potential stream issues like black screens, frozen frames, or incorrect scenes",
+			Arguments: []*mcpsdk.PromptArgument{{
+				Name:        "screenshot_source",
+				Description: "Name of the screenshot source to analyze for problems",
+				Required:    true,
+			}},
+		},
+		s.handleProblemDetection,
+	)
+
+	// Prompt 7: Preset Switcher
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "preset-switcher",
+			Description: "Manage scene presets: list available presets and optionally apply one",
+			Arguments: []*mcpsdk.PromptArgument{{
+				Name:        "preset_name",
+				Description: "Optional name of the preset to apply",
+				Required:    false,
+			}},
+		},
+		s.handlePresetSwitcher,
+	)
+
+	// Prompt 8: Recording Workflow
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "recording-workflow",
+			Description: "Guide through recording operations: check status, start/stop, verify scene and audio",
+		},
+		s.handleRecordingWorkflow,
+	)
+
+	// Prompt 9: Scene Organizer
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "scene-organizer",
+			Description: "Analyze scene structure and organization to suggest improvements",
+		},
+		s.handleSceneOrganizer,
+	)
+
+	// Prompt 10: Quick Status
+	s.mcpServer.AddPrompt(
+		&mcpsdk.Prompt{
+			Name:        "quick-status",
+			Description: "Get a brief summary of current OBS state (scene, recording, streaming)",
+		},
+		s.handleQuickStatus,
+	)
+
+	log.Println("Prompt handlers registered successfully")
+}
+
+// Prompt handler implementations
+
+// handleStreamLaunch provides a pre-stream checklist workflow
+func (s *Server) handleStreamLaunch(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling stream-launch prompt")
+
+	promptText := `Help me launch my stream with these comprehensive checks:
+
+1. **Verify OBS Connection**
+   - Use get_obs_status to confirm OBS is connected and responsive
+   - Report OBS version and connection state
+
+2. **List All Available Scenes**
+   - Use list_scenes to get all scenes
+   - Identify the current active scene
+   - Confirm the correct scene is selected for stream start
+
+3. **Audio Source Verification**
+   - Use list_sources to find all audio inputs
+   - For each audio input, check mute states with get_input_mute
+   - Check volume levels with get_input_volume
+   - Report any audio sources that are muted or have unusual volume levels
+
+4. **Check Recording and Streaming Status**
+   - Use get_streaming_status to verify streaming is not already active
+   - Use get_recording_status to check if recording is active
+   - Report current state of both
+
+5. **Provide Pre-Stream Recommendations**
+   - Identify any issues that should be resolved before going live
+   - Suggest adjustments to scene selection, audio levels, or mute states
+   - Confirm when everything is ready for streaming
+
+After completing all checks, provide a clear summary of OBS readiness for streaming.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Pre-stream checklist to verify OBS is ready for streaming",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleStreamTeardown provides post-stream cleanup workflow
+func (s *Server) handleStreamTeardown(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling stream-teardown prompt")
+
+	promptText := `Help me properly end my stream with these cleanup steps:
+
+1. **Stop Active Streaming**
+   - Use get_streaming_status to check if streaming is active
+   - If streaming, use stop_streaming to end the stream
+   - Confirm streaming has stopped successfully
+
+2. **Stop Active Recording**
+   - Use get_recording_status to check if recording is active
+   - If recording, use stop_recording to save the recording
+   - Report the output file path where the recording was saved
+
+3. **Switch to Offline Scene**
+   - Use list_scenes to identify available scenes
+   - Look for scenes named "Offline", "BRB", "End Screen", or similar
+   - If an offline scene exists, use set_current_scene to switch to it
+   - If no offline scene exists, suggest creating one for future use
+
+4. **Mute All Audio Inputs**
+   - Use list_sources to find all audio inputs
+   - For each audio input, check mute state with get_input_mute
+   - If any inputs are unmuted, use toggle_input_mute to mute them
+   - Confirm all audio is muted
+
+5. **Final Status Confirmation**
+   - Verify streaming is stopped
+   - Verify recording is stopped
+   - Confirm scene is set to offline/end screen
+   - Confirm all audio is muted
+
+Provide a summary of all teardown actions completed.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Post-stream cleanup to stop streaming/recording and switch to offline scene",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleAudioCheck provides audio verification workflow
+func (s *Server) handleAudioCheck(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling audio-check prompt")
+
+	promptText := `Help me verify all audio inputs are configured correctly:
+
+1. **List All Audio Inputs**
+   - Use list_sources to get all available sources
+   - Filter to identify audio inputs (microphone, desktop audio, music, etc.)
+   - Report the total count of audio inputs found
+
+2. **Check Mute States**
+   - For each audio input, use get_input_mute to check if it's muted
+   - Report which inputs are muted and which are unmuted
+   - Identify any unexpected mute states (e.g., microphone muted when it should be live)
+
+3. **Check Volume Levels**
+   - For each audio input, use get_input_volume to get current volume
+   - Report volume in both dB and multiplier format
+   - Identify any inputs with unusual volumes (too quiet, too loud, or at 0)
+
+4. **Identify Audio Issues**
+   - Flag any microphones that are muted
+   - Flag any desktop audio sources that are unmuted (if unexpected)
+   - Flag any volume levels outside normal ranges (-30dB to 0dB)
+   - Flag any inputs set to 0% volume
+
+5. **Provide Audio Recommendations**
+   - Suggest which inputs should be unmuted for streaming/recording
+   - Recommend volume adjustments if levels are too low or too high
+   - Confirm when audio configuration is optimal
+
+Provide a detailed audio configuration report with clear recommendations.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Verify all audio inputs are configured correctly with proper mute states and volumes",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleVisualCheck provides screenshot-based visual analysis workflow
+func (s *Server) handleVisualCheck(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling visual-check prompt")
+
+	screenshotSource := ""
+	if val, ok := req.Params.Arguments["screenshot_source"]; ok {
+		screenshotSource = val
+	}
+
+	if screenshotSource == "" {
+		return nil, fmt.Errorf("screenshot_source argument is required")
+	}
+
+	promptText := fmt.Sprintf(`Help me verify the visual layout of my stream using screenshot analysis:
+
+1. **Capture Current Screenshot**
+   - Use list_screenshot_sources to verify screenshot source '%s' exists
+   - If it doesn't exist, guide me to create it with create_screenshot_source
+   - Access the screenshot at the HTTP URL provided by the screenshot source
+
+2. **Analyze Visual Layout**
+   - Examine the screenshot to identify all visible elements
+   - Describe the scene composition (camera position, overlays, text, graphics)
+   - Check if all expected visual elements are present and visible
+
+3. **Check for Visual Issues**
+   - Look for black screens or blank areas
+   - Identify any frozen frames or static images
+   - Check for visual glitches, artifacts, or rendering issues
+   - Verify text is readable and not cut off
+   - Check for proper aspect ratios and scaling
+
+4. **Evaluate Stream Quality**
+   - Assess overall visual quality and professionalism
+   - Check color balance and brightness
+   - Verify overlays and graphics are positioned correctly
+   - Identify any visual elements that overlap inappropriately
+
+5. **Provide Visual Recommendations**
+   - Suggest improvements to layout and composition
+   - Recommend adjustments to source positioning or sizing
+   - Flag any critical issues that need immediate attention
+   - Confirm when the visual setup is stream-ready
+
+Provide a detailed visual analysis report with actionable recommendations.
+
+Screenshot source to analyze: %s`, screenshotSource, screenshotSource)
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Analyze a screenshot to verify the stream layout and identify any visual issues",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleHealthCheck provides comprehensive OBS diagnostic workflow
+func (s *Server) handleHealthCheck(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling health-check prompt")
+
+	promptText := `Help me run a comprehensive diagnostic of OBS to ensure everything is working correctly:
+
+1. **OBS Connection Status**
+   - Use get_obs_status to verify connection to OBS
+   - Report OBS version, connection state, and WebSocket status
+   - Flag any connection issues
+
+2. **Scene Inventory**
+   - Use list_scenes to get all available scenes
+   - Report total scene count
+   - Identify the current active scene
+   - Check if critical scenes exist (Main, Offline, BRB, etc.)
+
+3. **Source Count and Status**
+   - Use list_sources to get all input sources
+   - Report total source count by type (audio, video, image, text, etc.)
+   - Identify any disabled or problematic sources
+
+4. **Recording State**
+   - Use get_recording_status to check recording state
+   - Report if recording is active, paused, or stopped
+   - If recording is active, report duration and output path
+
+5. **Streaming State**
+   - Use get_streaming_status to check streaming state
+   - Report if streaming is active or stopped
+   - If streaming is active, report duration and connection status
+
+6. **Screenshot Sources**
+   - Use list_screenshot_sources to check configured screenshot sources
+   - Report which screenshot sources are active
+   - Verify screenshot HTTP endpoints are accessible
+
+7. **Overall Health Assessment**
+   - Identify any warning signs or issues detected
+   - Provide recommendations for optimization
+   - Confirm overall OBS health status (Healthy, Warning, Critical)
+
+Provide a comprehensive health report with clear status indicators for each category.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Run a comprehensive diagnostic of OBS connection, scenes, sources, and streaming state",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleProblemDetection provides screenshot-based issue detection workflow
+func (s *Server) handleProblemDetection(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling problem-detection prompt")
+
+	screenshotSource := ""
+	if val, ok := req.Params.Arguments["screenshot_source"]; ok {
+		screenshotSource = val
+	}
+
+	if screenshotSource == "" {
+		return nil, fmt.Errorf("screenshot_source argument is required")
+	}
+
+	promptText := fmt.Sprintf(`Help me detect potential streaming issues by analyzing the current screenshot:
+
+1. **Capture and Access Screenshot**
+   - Use list_screenshot_sources to verify screenshot source '%s' exists
+   - Access the latest screenshot from the HTTP URL
+   - Confirm the screenshot loaded successfully
+
+2. **Black Screen Detection**
+   - Analyze the screenshot for completely black or blank screens
+   - Check if the image is mostly black (>90%% black pixels)
+   - If detected, report as CRITICAL issue
+
+3. **Frozen Frame Detection**
+   - Compare with previous screenshots if available
+   - Look for static elements that should be dynamic (timers, animations)
+   - Report if the scene appears frozen or static
+
+4. **Wrong Scene Detection**
+   - Use list_scenes and identify the current active scene
+   - Analyze screenshot content to verify it matches the expected scene
+   - Check if an "Offline" or "BRB" scene is active when it shouldn't be
+   - Flag if the wrong scene appears to be active
+
+5. **Visual Artifact Detection**
+   - Look for visual glitches, corruption, or rendering errors
+   - Identify any overlapping elements that obscure important content
+   - Check for missing sources that should be visible
+
+6. **Audio-Visual Sync Issues**
+   - Check if audio sources are present in the scene
+   - Verify expected audio-visual sources are visible (e.g., waveform displays)
+
+7. **Problem Report and Recommendations**
+   - List all detected issues with severity (CRITICAL, WARNING, INFO)
+   - Provide specific recommendations to fix each issue
+   - If no issues found, confirm stream appears healthy
+
+Provide a detailed problem detection report with prioritized issues and solutions.
+
+Screenshot source to analyze: %s`, screenshotSource, screenshotSource)
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Detect potential stream issues like black screens, frozen frames, or incorrect scenes",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handlePresetSwitcher provides scene preset management workflow
+func (s *Server) handlePresetSwitcher(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling preset-switcher prompt")
+
+	presetName := ""
+	if val, ok := req.Params.Arguments["preset_name"]; ok {
+		presetName = val
+	}
+
+	promptText := `Help me manage scene presets for quick configuration switching:
+
+1. **List Available Presets**
+   - Use list_scene_presets to get all saved presets
+   - Display preset names, associated scene names, and creation dates
+   - Report total count of available presets
+
+2. **Show Current Scene State**
+   - Use list_scenes to identify the current active scene
+   - Use the scene resource (obs://scene/{name}) to get current source visibility states
+   - Describe which sources are currently visible/hidden`
+
+	if presetName != "" {
+		promptText += fmt.Sprintf(`
+
+3. **Apply Requested Preset**
+   - Use get_preset_details to view preset '%s' configuration
+   - Use apply_scene_preset to apply preset '%s'
+   - Confirm which sources were enabled/disabled
+   - Report success or any issues encountered`, presetName, presetName)
+	} else {
+		promptText += `
+
+3. **Preset Selection Guidance**
+   - Ask which preset I want to apply (if any)
+   - Explain what each preset does based on its scene and source configuration
+   - If I want to apply a preset, use apply_scene_preset with the chosen name`
+	}
+
+	promptText += `
+
+4. **Preset Recommendations**
+   - Suggest which preset might be appropriate for my current streaming activity
+   - Offer to create a new preset to save the current scene configuration
+   - Explain the benefits of using presets for quick scene setup
+
+Provide a clear preset management interface with actionable options.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Manage scene presets: list available presets and optionally apply one",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleRecordingWorkflow provides recording management workflow
+func (s *Server) handleRecordingWorkflow(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling recording-workflow prompt")
+
+	promptText := `Help me manage my recording session with proper workflow:
+
+1. **Check Current Recording Status**
+   - Use get_recording_status to check if recording is active, paused, or stopped
+   - If recording is active, report duration and output path
+   - If recording is paused, show pause duration
+
+2. **Verify Scene is Ready**
+   - Use list_scenes to identify the current scene
+   - Confirm the correct scene is active for recording
+   - If wrong scene, suggest switching with set_current_scene
+
+3. **Verify Audio Configuration**
+   - Use list_sources to identify audio inputs
+   - For each audio input, check mute state with get_input_mute
+   - Check audio levels with get_input_volume
+   - Flag any audio sources that should be unmuted but aren't
+
+4. **Recording Control Guidance**
+   - If not recording: offer to start_recording after confirming setup is ready
+   - If recording: offer to pause_recording or stop_recording
+   - If paused: offer to resume_recording or stop_recording
+   - Explain the implications of each action
+
+5. **Post-Recording Actions**
+   - When stopping recording, report the final output file path
+   - Confirm recording duration and file size (if available)
+   - Suggest next steps (review recording, start new recording, etc.)
+
+6. **Recording Best Practices**
+   - Recommend checking disk space before starting long recordings
+   - Suggest testing audio levels before recording important content
+   - Remind about scene setup and preset usage
+
+Provide a guided recording management experience with clear options.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Guide through recording operations: check status, start/stop, verify scene and audio",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleSceneOrganizer provides scene analysis and organization workflow
+func (s *Server) handleSceneOrganizer(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling scene-organizer prompt")
+
+	promptText := `Help me analyze and organize my OBS scenes for better workflow:
+
+1. **List All Scenes**
+   - Use list_scenes to get all available scenes
+   - Report total scene count
+   - Identify the current active scene
+
+2. **Analyze Each Scene Structure**
+   - For each scene, use the scene resource (obs://scene/{name}) to get details
+   - Report the number of sources in each scene
+   - List source types (image, video, audio, text, browser, etc.)
+   - Identify which sources are enabled vs disabled
+
+3. **Identify Scene Naming Patterns**
+   - Analyze scene names for organization patterns
+   - Check for common scene types (Main, Gaming, Chatting, Offline, BRB, etc.)
+   - Flag any scenes with unclear or generic names
+
+4. **Check for Scene Redundancy**
+   - Identify scenes with very similar source configurations
+   - Suggest consolidating redundant scenes
+   - Recommend using scene presets instead of duplicate scenes
+
+5. **Evaluate Scene Completeness**
+   - Check if essential scenes exist (Main scene, Offline scene, BRB scene)
+   - Identify missing scene types that might be useful
+   - Flag empty scenes or scenes with no visible sources
+
+6. **Organization Recommendations**
+   - Suggest better naming conventions for clarity
+   - Recommend scene ordering or grouping strategies
+   - Propose creating scene presets for frequently used configurations
+   - Suggest which scenes could be deleted or consolidated
+
+7. **Scene Workflow Optimization**
+   - Identify commonly used scene transitions
+   - Suggest preset creation for quick scene setup
+   - Recommend scene organization best practices
+
+Provide a detailed scene organization report with actionable improvement suggestions.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Analyze scene structure and organization to suggest improvements",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}
+
+// handleQuickStatus provides brief OBS status overview
+func (s *Server) handleQuickStatus(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+	log.Println("Handling quick-status prompt")
+
+	promptText := `Give me a brief summary of my current OBS state:
+
+1. **Current Scene**
+   - Use list_scenes to identify the active scene
+   - Report just the scene name
+
+2. **Recording Status**
+   - Use get_recording_status to check recording state
+   - Report: "Recording: Yes (duration)" or "Recording: No"
+   - If recording is paused, report: "Recording: Paused (duration)"
+
+3. **Streaming Status**
+   - Use get_streaming_status to check streaming state
+   - Report: "Streaming: Yes (duration)" or "Streaming: No"
+
+4. **Brief Format**
+   - Present all information in a concise, easy-to-read format
+   - Use simple yes/no answers with minimal details
+   - Total response should be 3-4 lines maximum
+
+Example output format:
+---
+Current Scene: Gaming
+Recording: Yes (15:23)
+Streaming: Yes (12:45)
+---
+
+Keep it short and clear - this is a quick status check, not a detailed report.`
+
+	return &mcpsdk.GetPromptResult{
+		Description: "Get a brief summary of current OBS state (scene, recording, streaming)",
+		Messages: []*mcpsdk.PromptMessage{{
+			Role: "user",
+			Content: &mcpsdk.TextContent{
+				Text: promptText,
+			},
+		}},
+	}, nil
+}

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -1,0 +1,715 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironystock/agentic-obs/internal/mcp/testutil"
+)
+
+// testPromptServer creates a minimal server for prompt testing.
+func testPromptServer(t *testing.T) *Server {
+	t.Helper()
+
+	mock := testutil.NewMockOBSClient()
+	mock.Connect()
+
+	server := &Server{
+		obsClient: mock,
+		ctx:       context.Background(),
+	}
+
+	return server
+}
+
+// TestPromptHandlers tests that each prompt handler returns a valid result
+func TestPromptHandlers(t *testing.T) {
+	tests := []struct {
+		name        string
+		handler     func(*Server) (*mcpsdk.GetPromptResult, error)
+		checkResult func(t *testing.T, result *mcpsdk.GetPromptResult)
+	}{
+		{
+			name: "stream-launch",
+			handler: func(s *Server) (*mcpsdk.GetPromptResult, error) {
+				return s.handleStreamLaunch(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+			checkResult: func(t *testing.T, result *mcpsdk.GetPromptResult) {
+				assert.Contains(t, result.Description, "Pre-stream checklist")
+				assert.Len(t, result.Messages, 1)
+				assert.Equal(t, mcpsdk.Role("user"), result.Messages[0].Role)
+				textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+				assert.Contains(t, textContent.Text, "connection")
+				assert.Contains(t, textContent.Text, "scenes")
+				assert.Contains(t, textContent.Text, "audio")
+			},
+		},
+		{
+			name: "stream-teardown",
+			handler: func(s *Server) (*mcpsdk.GetPromptResult, error) {
+				return s.handleStreamTeardown(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+			checkResult: func(t *testing.T, result *mcpsdk.GetPromptResult) {
+				assert.Contains(t, result.Description, "Post-stream cleanup")
+				assert.Len(t, result.Messages, 1)
+				textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+				assert.Contains(t, textContent.Text, "Stop Active Streaming")
+				assert.Contains(t, textContent.Text, "Offline Scene")
+			},
+		},
+		{
+			name: "audio-check",
+			handler: func(s *Server) (*mcpsdk.GetPromptResult, error) {
+				return s.handleAudioCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+			checkResult: func(t *testing.T, result *mcpsdk.GetPromptResult) {
+				assert.Contains(t, result.Description, "audio inputs")
+				assert.Len(t, result.Messages, 1)
+				textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+				assert.Contains(t, textContent.Text, "Mute States")
+				assert.Contains(t, textContent.Text, "Volume Levels")
+			},
+		},
+		{
+			name: "health-check",
+			handler: func(s *Server) (*mcpsdk.GetPromptResult, error) {
+				return s.handleHealthCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+			checkResult: func(t *testing.T, result *mcpsdk.GetPromptResult) {
+				assert.Contains(t, result.Description, "comprehensive diagnostic")
+				assert.Len(t, result.Messages, 1)
+				textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+				assert.Contains(t, textContent.Text, "Connection Status")
+				assert.Contains(t, textContent.Text, "Scene Inventory")
+			},
+		},
+		{
+			name: "recording-workflow",
+			handler: func(s *Server) (*mcpsdk.GetPromptResult, error) {
+				return s.handleRecordingWorkflow(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+			checkResult: func(t *testing.T, result *mcpsdk.GetPromptResult) {
+				assert.Contains(t, result.Description, "recording operations")
+				assert.Len(t, result.Messages, 1)
+				textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+				assert.Contains(t, textContent.Text, "Recording Status")
+				assert.Contains(t, textContent.Text, "Recording Control")
+			},
+		},
+		{
+			name: "scene-organizer",
+			handler: func(s *Server) (*mcpsdk.GetPromptResult, error) {
+				return s.handleSceneOrganizer(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+			checkResult: func(t *testing.T, result *mcpsdk.GetPromptResult) {
+				assert.Contains(t, result.Description, "scene structure")
+				assert.Len(t, result.Messages, 1)
+				textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+				assert.Contains(t, textContent.Text, "List All Scenes")
+				assert.Contains(t, textContent.Text, "Organization Recommendations")
+			},
+		},
+		{
+			name: "quick-status",
+			handler: func(s *Server) (*mcpsdk.GetPromptResult, error) {
+				return s.handleQuickStatus(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+			checkResult: func(t *testing.T, result *mcpsdk.GetPromptResult) {
+				assert.Contains(t, result.Description, "brief summary")
+				assert.Len(t, result.Messages, 1)
+				textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+				assert.Contains(t, textContent.Text, "Current Scene")
+				assert.Contains(t, textContent.Text, "Recording")
+				assert.Contains(t, textContent.Text, "Streaming")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := testPromptServer(t)
+			result, err := tt.handler(server)
+
+			require.NoError(t, err, "Handler should not return error")
+			require.NotNil(t, result, "Result should not be nil")
+			tt.checkResult(t, result)
+		})
+	}
+}
+
+// TestPromptArgumentValidation tests argument handling for prompts with required arguments
+func TestPromptArgumentValidation(t *testing.T) {
+	t.Run("visual-check with missing screenshot_source returns error", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{},
+			},
+		}
+
+		result, err := server.handleVisualCheck(context.Background(), req)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "screenshot_source argument is required")
+		assert.Nil(t, result)
+	})
+
+	t.Run("visual-check with screenshot_source succeeds", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"screenshot_source": "main-stream",
+				},
+			},
+		}
+
+		result, err := server.handleVisualCheck(context.Background(), req)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Messages, 1)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+		assert.Contains(t, textContent.Text, "main-stream")
+	})
+
+	t.Run("problem-detection with missing screenshot_source returns error", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{},
+			},
+		}
+
+		result, err := server.handleProblemDetection(context.Background(), req)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "screenshot_source argument is required")
+		assert.Nil(t, result)
+	})
+
+	t.Run("problem-detection with screenshot_source succeeds", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"screenshot_source": "main-stream",
+				},
+			},
+		}
+
+		result, err := server.handleProblemDetection(context.Background(), req)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Messages, 1)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+		assert.Contains(t, textContent.Text, "main-stream")
+		assert.Contains(t, textContent.Text, "Black Screen Detection")
+	})
+
+	t.Run("preset-switcher without preset_name succeeds", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{},
+			},
+		}
+
+		result, err := server.handlePresetSwitcher(context.Background(), req)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Messages, 1)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+		assert.Contains(t, textContent.Text, "Preset Selection Guidance")
+	})
+
+	t.Run("preset-switcher with preset_name includes apply instructions", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"preset_name": "Gaming Setup",
+				},
+			},
+		}
+
+		result, err := server.handlePresetSwitcher(context.Background(), req)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Messages, 1)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+		assert.Contains(t, textContent.Text, "Gaming Setup")
+		assert.Contains(t, textContent.Text, "Apply Requested Preset")
+		// Count occurrences of "Gaming Setup" - should appear twice
+		count := strings.Count(textContent.Text, "Gaming Setup")
+		assert.Equal(t, 2, count, "Preset name should appear twice in apply instructions")
+	})
+}
+
+// TestPromptMessageContent verifies that prompt messages contain expected content
+func TestPromptMessageContent(t *testing.T) {
+	t.Run("stream-launch contains comprehensive checklist", func(t *testing.T) {
+		server := testPromptServer(t)
+		result, err := server.handleStreamLaunch(context.Background(), &mcpsdk.GetPromptRequest{})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		// Verify key sections
+		assert.Contains(t, textContent.Text, "get_obs_status")
+		assert.Contains(t, textContent.Text, "list_scenes")
+		assert.Contains(t, textContent.Text, "list_sources")
+		assert.Contains(t, textContent.Text, "get_input_mute")
+		assert.Contains(t, textContent.Text, "get_streaming_status")
+		assert.Contains(t, textContent.Text, "get_recording_status")
+	})
+
+	t.Run("quick-status is concise", func(t *testing.T) {
+		server := testPromptServer(t)
+		result, err := server.handleQuickStatus(context.Background(), &mcpsdk.GetPromptRequest{})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		// Verify it mentions brevity
+		assert.Contains(t, textContent.Text, "brief")
+		assert.Contains(t, textContent.Text, "concise")
+		assert.Contains(t, textContent.Text, "3-4 lines")
+	})
+
+	t.Run("visual-check mentions screenshot analysis", func(t *testing.T) {
+		server := testPromptServer(t)
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"screenshot_source": "test-source",
+				},
+			},
+		}
+		result, err := server.handleVisualCheck(context.Background(), req)
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "Analyze Visual Layout")
+		assert.Contains(t, textContent.Text, "Visual Issues")
+		assert.Contains(t, textContent.Text, "test-source")
+	})
+
+	t.Run("problem-detection includes severity levels", func(t *testing.T) {
+		server := testPromptServer(t)
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"screenshot_source": "monitor",
+				},
+			},
+		}
+		result, err := server.handleProblemDetection(context.Background(), req)
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "CRITICAL")
+		assert.Contains(t, textContent.Text, "WARNING")
+		assert.Contains(t, textContent.Text, "Black Screen Detection")
+		assert.Contains(t, textContent.Text, "Frozen Frame Detection")
+	})
+
+	t.Run("audio-check includes comprehensive checks", func(t *testing.T) {
+		server := testPromptServer(t)
+		result, err := server.handleAudioCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "get_input_mute")
+		assert.Contains(t, textContent.Text, "get_input_volume")
+		assert.Contains(t, textContent.Text, "dB")
+		assert.Contains(t, textContent.Text, "multiplier")
+	})
+
+	t.Run("health-check covers all systems", func(t *testing.T) {
+		server := testPromptServer(t)
+		result, err := server.handleHealthCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "Connection Status")
+		assert.Contains(t, textContent.Text, "Scene Inventory")
+		assert.Contains(t, textContent.Text, "Source Count")
+		assert.Contains(t, textContent.Text, "Recording State")
+		assert.Contains(t, textContent.Text, "Streaming State")
+		assert.Contains(t, textContent.Text, "Screenshot Sources")
+	})
+
+	t.Run("scene-organizer includes organization analysis", func(t *testing.T) {
+		server := testPromptServer(t)
+		result, err := server.handleSceneOrganizer(context.Background(), &mcpsdk.GetPromptRequest{})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "Scene Naming Patterns")
+		assert.Contains(t, textContent.Text, "Scene Redundancy")
+		assert.Contains(t, textContent.Text, "Scene Completeness")
+		assert.Contains(t, textContent.Text, "Organization Recommendations")
+	})
+
+	t.Run("recording-workflow includes workflow steps", func(t *testing.T) {
+		server := testPromptServer(t)
+		result, err := server.handleRecordingWorkflow(context.Background(), &mcpsdk.GetPromptRequest{})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "start_recording")
+		assert.Contains(t, textContent.Text, "pause_recording")
+		assert.Contains(t, textContent.Text, "resume_recording")
+		assert.Contains(t, textContent.Text, "stop_recording")
+	})
+
+	t.Run("stream-teardown includes cleanup steps", func(t *testing.T) {
+		server := testPromptServer(t)
+		result, err := server.handleStreamTeardown(context.Background(), &mcpsdk.GetPromptRequest{})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "stop_streaming")
+		assert.Contains(t, textContent.Text, "stop_recording")
+		assert.Contains(t, textContent.Text, "Offline")
+		assert.Contains(t, textContent.Text, "Mute All Audio")
+	})
+}
+
+// TestPromptMessageStructure verifies that all prompts return valid message structures
+func TestPromptMessageStructure(t *testing.T) {
+	server := testPromptServer(t)
+
+	prompts := []struct {
+		name    string
+		handler func() (*mcpsdk.GetPromptResult, error)
+	}{
+		{
+			name: "stream-launch",
+			handler: func() (*mcpsdk.GetPromptResult, error) {
+				return server.handleStreamLaunch(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+		},
+		{
+			name: "stream-teardown",
+			handler: func() (*mcpsdk.GetPromptResult, error) {
+				return server.handleStreamTeardown(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+		},
+		{
+			name: "audio-check",
+			handler: func() (*mcpsdk.GetPromptResult, error) {
+				return server.handleAudioCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+		},
+		{
+			name: "health-check",
+			handler: func() (*mcpsdk.GetPromptResult, error) {
+				return server.handleHealthCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+		},
+		{
+			name: "recording-workflow",
+			handler: func() (*mcpsdk.GetPromptResult, error) {
+				return server.handleRecordingWorkflow(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+		},
+		{
+			name: "scene-organizer",
+			handler: func() (*mcpsdk.GetPromptResult, error) {
+				return server.handleSceneOrganizer(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+		},
+		{
+			name: "quick-status",
+			handler: func() (*mcpsdk.GetPromptResult, error) {
+				return server.handleQuickStatus(context.Background(), &mcpsdk.GetPromptRequest{})
+			},
+		},
+	}
+
+	for _, tt := range prompts {
+		t.Run(tt.name+" has valid structure", func(t *testing.T) {
+			result, err := tt.handler()
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Verify description exists
+			assert.NotEmpty(t, result.Description, "Description should not be empty")
+
+			// Verify messages array
+			require.NotNil(t, result.Messages, "Messages should not be nil")
+			assert.Len(t, result.Messages, 1, "Should have exactly one message")
+
+			// Verify message role
+			assert.Equal(t, mcpsdk.Role("user"), result.Messages[0].Role, "Message role should be 'user'")
+
+			// Verify message content
+			require.NotNil(t, result.Messages[0].Content, "Message content should not be nil")
+			textContent, ok := result.Messages[0].Content.(*mcpsdk.TextContent)
+			require.True(t, ok, "Content should be TextContent type")
+			assert.NotEmpty(t, textContent.Text, "Text content should not be empty")
+		})
+	}
+}
+
+// TestPromptArgumentInterpolation tests that arguments are properly interpolated into prompts
+func TestPromptArgumentInterpolation(t *testing.T) {
+	t.Run("visual-check interpolates screenshot_source", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		testCases := []string{
+			"main-camera",
+			"stream-preview",
+			"test123",
+		}
+
+		for _, sourceName := range testCases {
+			req := &mcpsdk.GetPromptRequest{
+				Params: &mcpsdk.GetPromptParams{
+					Arguments: map[string]string{
+						"screenshot_source": sourceName,
+					},
+				},
+			}
+
+			result, err := server.handleVisualCheck(context.Background(), req)
+
+			require.NoError(t, err)
+			textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+			// Should appear at least twice in the text
+			count := strings.Count(textContent.Text, sourceName)
+			assert.GreaterOrEqual(t, count, 2, "Screenshot source should appear at least twice")
+		}
+	})
+
+	t.Run("problem-detection interpolates screenshot_source", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		sourceName := "monitoring-source"
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"screenshot_source": sourceName,
+				},
+			},
+		}
+
+		result, err := server.handleProblemDetection(context.Background(), req)
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		// Should appear at least twice in the text
+		count := strings.Count(textContent.Text, sourceName)
+		assert.GreaterOrEqual(t, count, 2, "Screenshot source should appear at least twice")
+	})
+
+	t.Run("preset-switcher interpolates preset_name when provided", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		presetName := "StreamingSetup"
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"preset_name": presetName,
+				},
+			},
+		}
+
+		result, err := server.handlePresetSwitcher(context.Background(), req)
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		// Preset name should appear in the text
+		assert.Contains(t, textContent.Text, presetName)
+		assert.Contains(t, textContent.Text, "Apply Requested Preset")
+	})
+
+	t.Run("preset-switcher without preset_name uses default guidance", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{},
+			},
+		}
+
+		result, err := server.handlePresetSwitcher(context.Background(), req)
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		assert.Contains(t, textContent.Text, "Preset Selection Guidance")
+		assert.NotContains(t, textContent.Text, "Apply Requested Preset")
+	})
+}
+
+// TestPromptEdgeCases tests edge cases and error conditions
+func TestPromptEdgeCases(t *testing.T) {
+	t.Run("nil request doesn't cause panic", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		// These handlers don't use req, should work with nil
+		assert.NotPanics(t, func() {
+			_, _ = server.handleStreamLaunch(context.Background(), nil)
+		})
+
+		assert.NotPanics(t, func() {
+			_, _ = server.handleQuickStatus(context.Background(), nil)
+		})
+	})
+
+	t.Run("empty screenshot_source is treated as missing", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"screenshot_source": "",
+				},
+			},
+		}
+
+		result, err := server.handleVisualCheck(context.Background(), req)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "required")
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty preset_name is treated as not provided", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		req := &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{
+					"preset_name": "",
+				},
+			},
+		}
+
+		result, err := server.handlePresetSwitcher(context.Background(), req)
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+
+		// Should use default guidance since preset_name is empty
+		assert.Contains(t, textContent.Text, "Preset Selection Guidance")
+	})
+
+	t.Run("context cancellation is handled", func(t *testing.T) {
+		server := testPromptServer(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		// Handlers should still work even with cancelled context
+		// since they don't do async operations
+		_, err := server.handleStreamLaunch(ctx, &mcpsdk.GetPromptRequest{})
+		assert.NoError(t, err)
+	})
+}
+
+// TestAllPromptsHaveNonEmptyMessages ensures all prompts return non-empty messages
+func TestAllPromptsHaveNonEmptyMessages(t *testing.T) {
+	server := testPromptServer(t)
+
+	// Test prompts without arguments
+	noArgPrompts := []struct {
+		name    string
+		handler func() (*mcpsdk.GetPromptResult, error)
+	}{
+		{"stream-launch", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handleStreamLaunch(context.Background(), &mcpsdk.GetPromptRequest{})
+		}},
+		{"stream-teardown", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handleStreamTeardown(context.Background(), &mcpsdk.GetPromptRequest{})
+		}},
+		{"audio-check", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handleAudioCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+		}},
+		{"health-check", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handleHealthCheck(context.Background(), &mcpsdk.GetPromptRequest{})
+		}},
+		{"recording-workflow", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handleRecordingWorkflow(context.Background(), &mcpsdk.GetPromptRequest{})
+		}},
+		{"scene-organizer", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handleSceneOrganizer(context.Background(), &mcpsdk.GetPromptRequest{})
+		}},
+		{"quick-status", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handleQuickStatus(context.Background(), &mcpsdk.GetPromptRequest{})
+		}},
+		{"preset-switcher", func() (*mcpsdk.GetPromptResult, error) {
+			return server.handlePresetSwitcher(context.Background(), &mcpsdk.GetPromptRequest{
+				Params: &mcpsdk.GetPromptParams{Arguments: map[string]string{}},
+			})
+		}},
+	}
+
+	for _, tt := range noArgPrompts {
+		t.Run(tt.name+" has non-empty message", func(t *testing.T) {
+			result, err := tt.handler()
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, result.Messages, 1)
+
+			textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+			assert.NotEmpty(t, textContent.Text)
+			// All messages should be at least 100 characters (reasonable minimum)
+			assert.Greater(t, len(textContent.Text), 100)
+		})
+	}
+
+	// Test prompts with required arguments
+	t.Run("visual-check has non-empty message", func(t *testing.T) {
+		result, err := server.handleVisualCheck(context.Background(), &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{"screenshot_source": "test"},
+			},
+		})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+		assert.Greater(t, len(textContent.Text), 100)
+	})
+
+	t.Run("problem-detection has non-empty message", func(t *testing.T) {
+		result, err := server.handleProblemDetection(context.Background(), &mcpsdk.GetPromptRequest{
+			Params: &mcpsdk.GetPromptParams{
+				Arguments: map[string]string{"screenshot_source": "test"},
+			},
+		})
+
+		require.NoError(t, err)
+		textContent := result.Messages[0].Content.(*mcpsdk.TextContent)
+		assert.Greater(t, len(textContent.Text), 100)
+	})
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -176,7 +176,7 @@ func (s *Server) handleScreenshotResourceRead(ctx context.Context, request *mcps
 	// Decode base64 image data to binary
 	imageData, err := base64.StdEncoding.DecodeString(screenshot.ImageData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode screenshot image data: %w", err)
+		return nil, fmt.Errorf("failed to decode screenshot image data (base64 length: %d): %w", len(screenshot.ImageData), err)
 	}
 
 	result := &mcpsdk.ReadResourceResult{

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -31,6 +32,30 @@ func (s *Server) registerResourceHandlers() {
 			MIMEType:    "application/json",
 		},
 		s.handleResourceRead,
+	)
+
+	// Register screenshot sources as resources with a URI template
+	// This allows accessing screenshots at obs://screenshot/{sourceName}
+	s.mcpServer.AddResourceTemplate(
+		&mcpsdk.ResourceTemplate{
+			URITemplate: "obs://screenshot/{sourceName}",
+			Name:        "Screenshot Source",
+			Description: "Latest screenshot from a configured screenshot source",
+			MIMEType:    "image/png",
+		},
+		s.handleScreenshotResourceRead,
+	)
+
+	// Register scene presets as resources with a URI template
+	// This allows accessing presets at obs://preset/{presetName}
+	s.mcpServer.AddResourceTemplate(
+		&mcpsdk.ResourceTemplate{
+			URITemplate: "obs://preset/{presetName}",
+			Name:        "Scene Preset",
+			Description: "Saved source visibility configuration for a scene",
+			MIMEType:    "application/json",
+		},
+		s.handlePresetResourceRead,
 	)
 
 	log.Println("Resource handlers registered successfully")
@@ -123,4 +148,118 @@ func convertSourcesToMap(sources []obs.SceneSource) []map[string]interface{} {
 		}
 	}
 	return result
+}
+
+// handleScreenshotResourceRead returns the latest screenshot binary data for a screenshot source
+func (s *Server) handleScreenshotResourceRead(ctx context.Context, request *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	uri := request.Params.URI
+	log.Printf("Handling screenshot resource read request for URI: %s", uri)
+
+	// Extract screenshot source name from URI (format: obs://screenshot/{sourceName})
+	sourceName, err := extractScreenshotNameFromURI(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid screenshot resource URI: %w", err)
+	}
+
+	// Get screenshot source from database
+	source, err := s.storage.GetScreenshotSourceByName(ctx, sourceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get screenshot source: %w", err)
+	}
+
+	// Get latest screenshot for this source
+	screenshot, err := s.storage.GetLatestScreenshot(ctx, source.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest screenshot: %w", err)
+	}
+
+	// Decode base64 image data to binary
+	imageData, err := base64.StdEncoding.DecodeString(screenshot.ImageData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode screenshot image data: %w", err)
+	}
+
+	result := &mcpsdk.ReadResourceResult{
+		Contents: []*mcpsdk.ResourceContents{
+			{
+				URI:      uri,
+				MIMEType: screenshot.MimeType,
+				Blob:     imageData,
+			},
+		},
+	}
+
+	log.Printf("Returning screenshot data for source: %s (%d bytes)", sourceName, len(imageData))
+	return result, nil
+}
+
+// handlePresetResourceRead returns detailed information about a specific scene preset
+func (s *Server) handlePresetResourceRead(ctx context.Context, request *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	uri := request.Params.URI
+	log.Printf("Handling preset resource read request for URI: %s", uri)
+
+	// Extract preset name from URI (format: obs://preset/{presetName})
+	presetName, err := extractPresetNameFromURI(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid preset resource URI: %w", err)
+	}
+
+	// Get preset from database
+	preset, err := s.storage.GetScenePreset(ctx, presetName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scene preset: %w", err)
+	}
+
+	// Format preset as JSON
+	presetData := map[string]interface{}{
+		"name":        preset.Name,
+		"scene_name":  preset.SceneName,
+		"sources":     preset.Sources,
+		"created_at":  preset.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		"description": fmt.Sprintf("Preset for scene '%s' with %d sources", preset.SceneName, len(preset.Sources)),
+	}
+
+	jsonData, err := json.MarshalIndent(presetData, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal preset details: %w", err)
+	}
+
+	result := &mcpsdk.ReadResourceResult{
+		Contents: []*mcpsdk.ResourceContents{
+			{
+				URI:      uri,
+				MIMEType: "application/json",
+				Text:     string(jsonData),
+			},
+		},
+	}
+
+	log.Printf("Returning preset details for: %s", presetName)
+	return result, nil
+}
+
+// extractScreenshotNameFromURI extracts the screenshot source name from a resource URI
+// Expected format: obs://screenshot/{sourceName}
+func extractScreenshotNameFromURI(uri string) (string, error) {
+	const prefix = "obs://screenshot/"
+	if len(uri) <= len(prefix) {
+		return "", fmt.Errorf("URI too short")
+	}
+	if uri[:len(prefix)] != prefix {
+		return "", fmt.Errorf("URI must start with %s", prefix)
+	}
+	return uri[len(prefix):], nil
+}
+
+// extractPresetNameFromURI extracts the preset name from a resource URI
+// Expected format: obs://preset/{presetName}
+func extractPresetNameFromURI(uri string) (string, error) {
+	const prefix = "obs://preset/"
+	if len(uri) <= len(prefix) {
+		return "", fmt.Errorf("URI too short")
+	}
+	if uri[:len(prefix)] != prefix {
+		return "", fmt.Errorf("URI must start with %s", prefix)
+	}
+	return uri[len(prefix):], nil
 }

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -11,6 +11,13 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// Resource URI prefixes for MCP resource identification
+const (
+	SceneURIPrefix      = "obs://scene/"
+	ScreenshotURIPrefix = "obs://screenshot/"
+	PresetURIPrefix     = "obs://preset/"
+)
+
 // SceneDetails contains detailed information about a scene
 type SceneDetails struct {
 	Name        string                   `json:"name"`
@@ -117,14 +124,13 @@ func (s *Server) handleResourceRead(ctx context.Context, request *mcpsdk.ReadRes
 // extractSceneNameFromURI extracts the scene name from a resource URI
 // Expected format: obs://scene/{scene_name}
 func extractSceneNameFromURI(uri string) (string, error) {
-	const prefix = "obs://scene/"
-	if len(uri) <= len(prefix) {
+	if len(uri) <= len(SceneURIPrefix) {
 		return "", fmt.Errorf("URI too short")
 	}
-	if uri[:len(prefix)] != prefix {
-		return "", fmt.Errorf("URI must start with %s", prefix)
+	if uri[:len(SceneURIPrefix)] != SceneURIPrefix {
+		return "", fmt.Errorf("URI must start with %s", SceneURIPrefix)
 	}
-	return uri[len(prefix):], nil
+	return uri[len(SceneURIPrefix):], nil
 }
 
 // convertSourcesToMap converts OBS SceneSource structs to generic map format for JSON serialization
@@ -241,25 +247,23 @@ func (s *Server) handlePresetResourceRead(ctx context.Context, request *mcpsdk.R
 // extractScreenshotNameFromURI extracts the screenshot source name from a resource URI
 // Expected format: obs://screenshot/{sourceName}
 func extractScreenshotNameFromURI(uri string) (string, error) {
-	const prefix = "obs://screenshot/"
-	if len(uri) <= len(prefix) {
+	if len(uri) <= len(ScreenshotURIPrefix) {
 		return "", fmt.Errorf("URI too short")
 	}
-	if uri[:len(prefix)] != prefix {
-		return "", fmt.Errorf("URI must start with %s", prefix)
+	if uri[:len(ScreenshotURIPrefix)] != ScreenshotURIPrefix {
+		return "", fmt.Errorf("URI must start with %s", ScreenshotURIPrefix)
 	}
-	return uri[len(prefix):], nil
+	return uri[len(ScreenshotURIPrefix):], nil
 }
 
 // extractPresetNameFromURI extracts the preset name from a resource URI
 // Expected format: obs://preset/{presetName}
 func extractPresetNameFromURI(uri string) (string, error) {
-	const prefix = "obs://preset/"
-	if len(uri) <= len(prefix) {
+	if len(uri) <= len(PresetURIPrefix) {
 		return "", fmt.Errorf("URI too short")
 	}
-	if uri[:len(prefix)] != prefix {
-		return "", fmt.Errorf("URI must start with %s", prefix)
+	if uri[:len(PresetURIPrefix)] != PresetURIPrefix {
+		return "", fmt.Errorf("URI must start with %s", PresetURIPrefix)
 	}
-	return uri[len(prefix):], nil
+	return uri[len(PresetURIPrefix):], nil
 }

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -114,3 +114,89 @@ func TestSceneDetails(t *testing.T) {
 		assert.Len(t, details.Sources, 1)
 	})
 }
+
+func TestExtractScreenshotNameFromURI(t *testing.T) {
+	t.Run("extracts screenshot name from valid URI", func(t *testing.T) {
+		name, err := extractScreenshotNameFromURI("obs://screenshot/gameplay")
+		assert.NoError(t, err)
+		assert.Equal(t, "gameplay", name)
+	})
+
+	t.Run("extracts screenshot name with spaces", func(t *testing.T) {
+		name, err := extractScreenshotNameFromURI("obs://screenshot/my monitor")
+		assert.NoError(t, err)
+		assert.Equal(t, "my monitor", name)
+	})
+
+	t.Run("extracts screenshot name with special characters", func(t *testing.T) {
+		name, err := extractScreenshotNameFromURI("obs://screenshot/webcam_1080p")
+		assert.NoError(t, err)
+		assert.Equal(t, "webcam_1080p", name)
+	})
+
+	t.Run("returns error for URI too short", func(t *testing.T) {
+		_, err := extractScreenshotNameFromURI("obs://screenshot/")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "too short")
+	})
+
+	t.Run("returns error for invalid prefix", func(t *testing.T) {
+		_, err := extractScreenshotNameFromURI("obs://scene/longenoughtestname")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must start with")
+	})
+
+	t.Run("returns error for wrong scheme", func(t *testing.T) {
+		_, err := extractScreenshotNameFromURI("http://screenshot/gameplay")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must start with")
+	})
+
+	t.Run("returns error for empty URI", func(t *testing.T) {
+		_, err := extractScreenshotNameFromURI("")
+		assert.Error(t, err)
+	})
+}
+
+func TestExtractPresetNameFromURI(t *testing.T) {
+	t.Run("extracts preset name from valid URI", func(t *testing.T) {
+		name, err := extractPresetNameFromURI("obs://preset/streaming")
+		assert.NoError(t, err)
+		assert.Equal(t, "streaming", name)
+	})
+
+	t.Run("extracts preset name with spaces", func(t *testing.T) {
+		name, err := extractPresetNameFromURI("obs://preset/my layout")
+		assert.NoError(t, err)
+		assert.Equal(t, "my layout", name)
+	})
+
+	t.Run("extracts preset name with special characters", func(t *testing.T) {
+		name, err := extractPresetNameFromURI("obs://preset/recording_setup_v2")
+		assert.NoError(t, err)
+		assert.Equal(t, "recording_setup_v2", name)
+	})
+
+	t.Run("returns error for URI too short", func(t *testing.T) {
+		_, err := extractPresetNameFromURI("obs://preset/")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "too short")
+	})
+
+	t.Run("returns error for invalid prefix", func(t *testing.T) {
+		_, err := extractPresetNameFromURI("obs://scene/test")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must start with")
+	})
+
+	t.Run("returns error for wrong scheme", func(t *testing.T) {
+		_, err := extractPresetNameFromURI("http://preset/streaming")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must start with")
+	})
+
+	t.Run("returns error for empty URI", func(t *testing.T) {
+		_, err := extractPresetNameFromURI("")
+		assert.Error(t, err)
+	})
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -95,6 +95,9 @@ func NewServer(config ServerConfig) (*Server, error) {
 	// Register tool handlers
 	s.registerToolHandlers()
 
+	// Register prompt handlers
+	s.registerPrompts()
+
 	log.Printf("MCP Server initialized: %s v%s", config.ServerName, config.ServerVersion)
 	return s, nil
 }


### PR DESCRIPTION
## Summary

- Add 2 new MCP resources (screenshots and presets) for a total of 3 resource types
- Add 10 MCP prompts for common OBS workflows
- Comprehensive test coverage (57 new tests)
- Full documentation updates

## MCP Resources (3 total)

| Resource | URI Pattern | Content Type |
|----------|-------------|--------------|
| Scenes | `obs://scene/{name}` | JSON |
| Screenshots | `obs://screenshot/{name}` | Binary image |
| Presets | `obs://preset/{name}` | JSON |

## MCP Prompts (10 total)

| Prompt | Arguments | Purpose |
|--------|-----------|---------|
| `stream-launch` | - | Pre-stream checklist |
| `stream-teardown` | - | End-stream cleanup |
| `audio-check` | - | Audio verification |
| `visual-check` | screenshot_source | Visual analysis |
| `health-check` | - | OBS diagnostic |
| `problem-detection` | screenshot_source | Issue detection |
| `preset-switcher` | preset_name (opt) | Preset management |
| `recording-workflow` | - | Recording session |
| `scene-organizer` | - | Scene organization |
| `quick-status` | - | Brief status |

## Files Changed

- `internal/mcp/resources.go` - Screenshot + preset resource handlers
- `internal/mcp/prompts.go` - New file with 10 prompt handlers (~650 lines)
- `internal/mcp/server.go` - Register prompts
- `internal/mcp/resources_test.go` - 14 new tests
- `internal/mcp/prompts_test.go` - New file with 43 tests (~715 lines)
- `CLAUDE.md`, `README.md`, `docs/TOOLS.md` - Documentation

## Test plan

- [x] `go build` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 57 new tests)
- [x] `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)