### PR TITLE
FB-12: Add MCP-UI Go SDK (pkg/mcpui)

### DIFF
--- a/docs/FB-15-mcpui-extraction.md
+++ b/docs/FB-15-mcpui-extraction.md
@@ -1,0 +1,171 @@
+# FB-15: mcpui-go Extraction & Documentation
+
+**Priority**: Low
+**Complexity**: Low-Medium
+**Dependencies**: FB-12 ✅, FB-13 (integration battle-testing)
+
+## Description
+Extract `pkg/mcpui/` to standalone repository `github.com/ironystock/mcpui-go` with full documentation and examples following the official MCP Go SDK patterns.
+
+## Current State
+- Core SDK complete in `pkg/mcpui/` (84.7% test coverage)
+- 12 source files, ~3,000 lines of code
+- `example_test.go` with 13 runnable examples
+- `doc.go` with package documentation
+
+---
+
+## Documentation Tasks (following go-sdk patterns)
+
+### README.md
+- [ ] Package overview and value proposition
+- [ ] "Getting Started" with minimal example
+- [ ] Package/feature documentation links
+- [ ] Installation instructions
+- [ ] License and acknowledgements
+
+### docs/ Directory
+
+| File | Description |
+|------|-------------|
+| `README.md` | Documentation index |
+| `content-types.md` | HTMLContent, URLContent, RemoteDOMContent, BlobContent |
+| `resources.md` | UIResource, UIResourceContents, validation |
+| `actions.md` | UIAction types, payloads, parsing |
+| `responses.md` | UIResponse builders, success/error handling |
+| `handlers.md` | UIActionHandler, Router, typed wrappers |
+| `integration.md` | How to integrate with MCP servers |
+
+### CONTRIBUTING.md
+- [ ] Contribution guidelines
+- [ ] Code style requirements
+- [ ] Testing requirements
+- [ ] PR process
+
+---
+
+## Examples Directory (following go-sdk patterns)
+
+```
+examples/
+├── basic/
+│   └── main.go          # Minimal HTML resource example
+├── router/
+│   └── main.go          # Router with multiple handlers
+├── remote-dom/
+│   └── main.go          # Remote DOM with React framework
+├── action-handling/
+│   └── main.go          # Complete action→response flow
+├── mcp-integration/
+│   └── main.go          # Integration with MCP server
+└── README.md            # Examples index
+```
+
+### Example: basic/main.go
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "github.com/ironystock/mcpui-go"
+)
+
+func main() {
+    // Create HTML content for a greeting card
+    content := &mcpui.HTMLContent{
+        HTML: `<div style="padding: 20px;">
+            <h1>Hello, World!</h1>
+            <p>This is rendered in a sandboxed iframe.</p>
+        </div>`,
+    }
+
+    // Create resource contents
+    rc, _ := mcpui.NewUIResourceContents("ui://greeting/hello", content)
+
+    data, _ := json.MarshalIndent(rc, "", "  ")
+    fmt.Println(string(data))
+}
+```
+
+### Example: router/main.go
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "github.com/ironystock/mcpui-go"
+)
+
+func main() {
+    router := mcpui.NewRouter()
+
+    // Handle tool actions
+    router.HandleType(mcpui.ActionTypeTool, mcpui.WrapToolHandler(
+        func(ctx context.Context, toolName string, params map[string]any) (any, error) {
+            return map[string]string{"executed": toolName}, nil
+        },
+    ))
+
+    // Handle specific resource
+    router.HandleResource("ui://dashboard/main", func(ctx context.Context, req *mcpui.UIActionRequest) (*mcpui.UIActionResult, error) {
+        return &mcpui.UIActionResult{Response: "dashboard handled"}, nil
+    })
+
+    fmt.Println("Router configured with", len(router.typeHandlers), "type handlers")
+}
+```
+
+---
+
+## Extraction Checklist
+
+### Phase 1: Repository Setup
+- [ ] Create `github.com/ironystock/mcpui-go` repository
+- [ ] Initialize go.mod with `module github.com/ironystock/mcpui-go`
+- [ ] Copy source files from `pkg/mcpui/`
+- [ ] Update import paths in examples
+- [ ] Add LICENSE (MIT)
+- [ ] Configure GitHub Actions for CI
+
+### Phase 2: Documentation
+- [ ] Write README.md with getting started
+- [ ] Create docs/ directory structure
+- [ ] Write content-types.md
+- [ ] Write resources.md
+- [ ] Write actions.md
+- [ ] Write responses.md
+- [ ] Write handlers.md
+- [ ] Write integration.md
+- [ ] Write CONTRIBUTING.md
+
+### Phase 3: Examples
+- [ ] Create examples/ directory
+- [ ] Write basic/ example
+- [ ] Write router/ example
+- [ ] Write remote-dom/ example
+- [ ] Write action-handling/ example
+- [ ] Write mcp-integration/ example
+- [ ] Write examples/README.md index
+
+### Phase 4: Polish
+- [ ] Ensure all public APIs have godoc
+- [ ] Add badges (Go Reference, CI status, coverage)
+- [ ] Create GitHub release v0.1.0
+- [ ] Submit to awesome-mcp list (if applicable)
+- [ ] Update agentic-obs to use external module
+
+---
+
+## Timeline Recommendation
+- Wait until FB-13 (MCP-UI Integration) is complete
+- Real-world usage in agentic-obs will identify API improvements
+- Extract after APIs are stable
+
+## Reference: go-sdk Structure
+The official MCP Go SDK has:
+- `README.md` - Overview, getting started
+- `docs/` - client.md, server.md, protocol.md, troubleshooting.md
+- `examples/` - 14 server examples (basic, completion, hello, memory, etc.)
+- `CONTRIBUTING.md` - Contribution guidelines

--- a/pkg/mcpui/action.go
+++ b/pkg/mcpui/action.go
@@ -1,0 +1,300 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ActionType constants define the types of UI actions.
+const (
+	// ActionTypeTool triggers a tool call on the MCP server.
+	ActionTypeTool = "tool"
+	// ActionTypeIntent signals a user intent for the AI to interpret.
+	ActionTypeIntent = "intent"
+	// ActionTypePrompt sends a prompt message to the AI.
+	ActionTypePrompt = "prompt"
+	// ActionTypeNotify sends a notification message to the host.
+	ActionTypeNotify = "notify"
+	// ActionTypeLink requests to open an external link.
+	ActionTypeLink = "link"
+	// ActionTypeUISize indicates a UI size change.
+	ActionTypeUISize = "ui-size-change"
+)
+
+// UIAction represents a user interaction from embedded UI.
+// Actions are sent from the iframe to the host via postMessage.
+type UIAction struct {
+	// Type is the action type (tool, intent, prompt, notify, link, ui-size-change).
+	Type string `json:"type"`
+	// MessageID is an optional identifier for correlating async responses.
+	MessageID string `json:"messageId,omitempty"`
+	// Payload contains the action-specific data.
+	Payload json.RawMessage `json:"payload"`
+}
+
+// ParsePayload parses the action payload into the appropriate type.
+func (a *UIAction) ParsePayload() (any, error) {
+	switch a.Type {
+	case ActionTypeTool:
+		var p ToolActionPayload
+		if err := json.Unmarshal(a.Payload, &p); err != nil {
+			return nil, fmt.Errorf("invalid tool payload: %w", err)
+		}
+		return &p, nil
+	case ActionTypeIntent:
+		var p IntentActionPayload
+		if err := json.Unmarshal(a.Payload, &p); err != nil {
+			return nil, fmt.Errorf("invalid intent payload: %w", err)
+		}
+		return &p, nil
+	case ActionTypePrompt:
+		var p PromptActionPayload
+		if err := json.Unmarshal(a.Payload, &p); err != nil {
+			return nil, fmt.Errorf("invalid prompt payload: %w", err)
+		}
+		return &p, nil
+	case ActionTypeNotify:
+		var p NotifyActionPayload
+		if err := json.Unmarshal(a.Payload, &p); err != nil {
+			return nil, fmt.Errorf("invalid notify payload: %w", err)
+		}
+		return &p, nil
+	case ActionTypeLink:
+		var p LinkActionPayload
+		if err := json.Unmarshal(a.Payload, &p); err != nil {
+			return nil, fmt.Errorf("invalid link payload: %w", err)
+		}
+		return &p, nil
+	case ActionTypeUISize:
+		var p UISizeActionPayload
+		if err := json.Unmarshal(a.Payload, &p); err != nil {
+			return nil, fmt.Errorf("invalid ui-size-change payload: %w", err)
+		}
+		return &p, nil
+	default:
+		return nil, fmt.Errorf("unknown action type: %s", a.Type)
+	}
+}
+
+// ToolPayload returns the payload as a ToolActionPayload if the action type is "tool".
+func (a *UIAction) ToolPayload() (*ToolActionPayload, error) {
+	if a.Type != ActionTypeTool {
+		return nil, fmt.Errorf("action type is %s, not tool", a.Type)
+	}
+	var p ToolActionPayload
+	if err := json.Unmarshal(a.Payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// IntentPayload returns the payload as an IntentActionPayload if the action type is "intent".
+func (a *UIAction) IntentPayload() (*IntentActionPayload, error) {
+	if a.Type != ActionTypeIntent {
+		return nil, fmt.Errorf("action type is %s, not intent", a.Type)
+	}
+	var p IntentActionPayload
+	if err := json.Unmarshal(a.Payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// PromptPayload returns the payload as a PromptActionPayload if the action type is "prompt".
+func (a *UIAction) PromptPayload() (*PromptActionPayload, error) {
+	if a.Type != ActionTypePrompt {
+		return nil, fmt.Errorf("action type is %s, not prompt", a.Type)
+	}
+	var p PromptActionPayload
+	if err := json.Unmarshal(a.Payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// NotifyPayload returns the payload as a NotifyActionPayload if the action type is "notify".
+func (a *UIAction) NotifyPayload() (*NotifyActionPayload, error) {
+	if a.Type != ActionTypeNotify {
+		return nil, fmt.Errorf("action type is %s, not notify", a.Type)
+	}
+	var p NotifyActionPayload
+	if err := json.Unmarshal(a.Payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// LinkPayload returns the payload as a LinkActionPayload if the action type is "link".
+func (a *UIAction) LinkPayload() (*LinkActionPayload, error) {
+	if a.Type != ActionTypeLink {
+		return nil, fmt.Errorf("action type is %s, not link", a.Type)
+	}
+	var p LinkActionPayload
+	if err := json.Unmarshal(a.Payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// UISizePayload returns the payload as a UISizeActionPayload if the action type is "ui-size-change".
+func (a *UIAction) UISizePayload() (*UISizeActionPayload, error) {
+	if a.Type != ActionTypeUISize {
+		return nil, fmt.Errorf("action type is %s, not ui-size-change", a.Type)
+	}
+	var p UISizeActionPayload
+	if err := json.Unmarshal(a.Payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// ToolActionPayload is the payload for tool actions.
+// It requests the host to execute an MCP tool.
+type ToolActionPayload struct {
+	// ToolName is the name of the tool to call.
+	ToolName string `json:"toolName"`
+	// Params are the tool parameters.
+	Params map[string]any `json:"params,omitempty"`
+}
+
+// IntentActionPayload is the payload for intent actions.
+// It signals a user intent for the AI to interpret and act upon.
+type IntentActionPayload struct {
+	// Intent is the user intent identifier.
+	Intent string `json:"intent"`
+	// Params are optional parameters for the intent.
+	Params map[string]any `json:"params,omitempty"`
+}
+
+// PromptActionPayload is the payload for prompt actions.
+// It sends a prompt message to the AI conversation.
+type PromptActionPayload struct {
+	// Prompt is the text to send to the AI.
+	Prompt string `json:"prompt"`
+}
+
+// NotifyActionPayload is the payload for notify actions.
+// It sends a notification message to the host.
+type NotifyActionPayload struct {
+	// Message is the notification text.
+	Message string `json:"message"`
+	// Level is an optional severity level (info, warning, error).
+	Level string `json:"level,omitempty"`
+}
+
+// LinkActionPayload is the payload for link actions.
+// It requests to open an external URL.
+type LinkActionPayload struct {
+	// URL is the external URL to open.
+	URL string `json:"url"`
+}
+
+// UISizeActionPayload is the payload for ui-size-change actions.
+// It notifies the host of UI dimension changes.
+type UISizeActionPayload struct {
+	// Height is the new height in pixels.
+	Height int `json:"height"`
+	// Width is the optional new width in pixels.
+	Width int `json:"width,omitempty"`
+}
+
+// NewToolAction creates a new tool action.
+func NewToolAction(messageID, toolName string, params map[string]any) (*UIAction, error) {
+	payload := ToolActionPayload{
+		ToolName: toolName,
+		Params:   params,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &UIAction{
+		Type:      ActionTypeTool,
+		MessageID: messageID,
+		Payload:   data,
+	}, nil
+}
+
+// NewIntentAction creates a new intent action.
+func NewIntentAction(messageID, intent string, params map[string]any) (*UIAction, error) {
+	payload := IntentActionPayload{
+		Intent: intent,
+		Params: params,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &UIAction{
+		Type:      ActionTypeIntent,
+		MessageID: messageID,
+		Payload:   data,
+	}, nil
+}
+
+// NewPromptAction creates a new prompt action.
+func NewPromptAction(messageID, prompt string) (*UIAction, error) {
+	payload := PromptActionPayload{
+		Prompt: prompt,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &UIAction{
+		Type:      ActionTypePrompt,
+		MessageID: messageID,
+		Payload:   data,
+	}, nil
+}
+
+// NewNotifyAction creates a new notify action.
+func NewNotifyAction(message string, level string) (*UIAction, error) {
+	payload := NotifyActionPayload{
+		Message: message,
+		Level:   level,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &UIAction{
+		Type:    ActionTypeNotify,
+		Payload: data,
+	}, nil
+}
+
+// NewLinkAction creates a new link action.
+func NewLinkAction(url string) (*UIAction, error) {
+	payload := LinkActionPayload{
+		URL: url,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &UIAction{
+		Type:    ActionTypeLink,
+		Payload: data,
+	}, nil
+}
+
+// NewUISizeAction creates a new UI size change action.
+func NewUISizeAction(height, width int) (*UIAction, error) {
+	payload := UISizeActionPayload{
+		Height: height,
+		Width:  width,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &UIAction{
+		Type:    ActionTypeUISize,
+		Payload: data,
+	}, nil
+}

--- a/pkg/mcpui/action_test.go
+++ b/pkg/mcpui/action_test.go
@@ -1,0 +1,305 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIAction_ParsePayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  *UIAction
+		wantErr bool
+		check   func(t *testing.T, payload any)
+	}{
+		{
+			name: "tool action",
+			action: &UIAction{
+				Type:    ActionTypeTool,
+				Payload: json.RawMessage(`{"toolName":"get_status","params":{"verbose":true}}`),
+			},
+			check: func(t *testing.T, payload any) {
+				p, ok := payload.(*ToolActionPayload)
+				require.True(t, ok)
+				assert.Equal(t, "get_status", p.ToolName)
+				assert.Equal(t, true, p.Params["verbose"])
+			},
+		},
+		{
+			name: "intent action",
+			action: &UIAction{
+				Type:    ActionTypeIntent,
+				Payload: json.RawMessage(`{"intent":"switch_scene","params":{"scene":"Gaming"}}`),
+			},
+			check: func(t *testing.T, payload any) {
+				p, ok := payload.(*IntentActionPayload)
+				require.True(t, ok)
+				assert.Equal(t, "switch_scene", p.Intent)
+				assert.Equal(t, "Gaming", p.Params["scene"])
+			},
+		},
+		{
+			name: "prompt action",
+			action: &UIAction{
+				Type:    ActionTypePrompt,
+				Payload: json.RawMessage(`{"prompt":"How do I start streaming?"}`),
+			},
+			check: func(t *testing.T, payload any) {
+				p, ok := payload.(*PromptActionPayload)
+				require.True(t, ok)
+				assert.Equal(t, "How do I start streaming?", p.Prompt)
+			},
+		},
+		{
+			name: "notify action",
+			action: &UIAction{
+				Type:    ActionTypeNotify,
+				Payload: json.RawMessage(`{"message":"Recording started","level":"info"}`),
+			},
+			check: func(t *testing.T, payload any) {
+				p, ok := payload.(*NotifyActionPayload)
+				require.True(t, ok)
+				assert.Equal(t, "Recording started", p.Message)
+				assert.Equal(t, "info", p.Level)
+			},
+		},
+		{
+			name: "link action",
+			action: &UIAction{
+				Type:    ActionTypeLink,
+				Payload: json.RawMessage(`{"url":"https://example.com/docs"}`),
+			},
+			check: func(t *testing.T, payload any) {
+				p, ok := payload.(*LinkActionPayload)
+				require.True(t, ok)
+				assert.Equal(t, "https://example.com/docs", p.URL)
+			},
+		},
+		{
+			name: "ui-size-change action",
+			action: &UIAction{
+				Type:    ActionTypeUISize,
+				Payload: json.RawMessage(`{"height":600,"width":800}`),
+			},
+			check: func(t *testing.T, payload any) {
+				p, ok := payload.(*UISizeActionPayload)
+				require.True(t, ok)
+				assert.Equal(t, 600, p.Height)
+				assert.Equal(t, 800, p.Width)
+			},
+		},
+		{
+			name: "unknown action type",
+			action: &UIAction{
+				Type:    "unknown",
+				Payload: json.RawMessage(`{}`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid payload",
+			action: &UIAction{
+				Type:    ActionTypeTool,
+				Payload: json.RawMessage(`not valid json`),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := tt.action.ParsePayload()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, payload)
+		})
+	}
+}
+
+func TestUIAction_TypedPayloadAccessors(t *testing.T) {
+	t.Run("ToolPayload", func(t *testing.T) {
+		action := &UIAction{
+			Type:    ActionTypeTool,
+			Payload: json.RawMessage(`{"toolName":"test_tool"}`),
+		}
+		p, err := action.ToolPayload()
+		require.NoError(t, err)
+		assert.Equal(t, "test_tool", p.ToolName)
+
+		// Wrong type
+		action.Type = ActionTypePrompt
+		_, err = action.ToolPayload()
+		assert.Error(t, err)
+	})
+
+	t.Run("IntentPayload", func(t *testing.T) {
+		action := &UIAction{
+			Type:    ActionTypeIntent,
+			Payload: json.RawMessage(`{"intent":"test_intent"}`),
+		}
+		p, err := action.IntentPayload()
+		require.NoError(t, err)
+		assert.Equal(t, "test_intent", p.Intent)
+	})
+
+	t.Run("PromptPayload", func(t *testing.T) {
+		action := &UIAction{
+			Type:    ActionTypePrompt,
+			Payload: json.RawMessage(`{"prompt":"test prompt"}`),
+		}
+		p, err := action.PromptPayload()
+		require.NoError(t, err)
+		assert.Equal(t, "test prompt", p.Prompt)
+	})
+
+	t.Run("NotifyPayload", func(t *testing.T) {
+		action := &UIAction{
+			Type:    ActionTypeNotify,
+			Payload: json.RawMessage(`{"message":"test"}`),
+		}
+		p, err := action.NotifyPayload()
+		require.NoError(t, err)
+		assert.Equal(t, "test", p.Message)
+	})
+
+	t.Run("LinkPayload", func(t *testing.T) {
+		action := &UIAction{
+			Type:    ActionTypeLink,
+			Payload: json.RawMessage(`{"url":"https://test.com"}`),
+		}
+		p, err := action.LinkPayload()
+		require.NoError(t, err)
+		assert.Equal(t, "https://test.com", p.URL)
+	})
+
+	t.Run("UISizePayload", func(t *testing.T) {
+		action := &UIAction{
+			Type:    ActionTypeUISize,
+			Payload: json.RawMessage(`{"height":100}`),
+		}
+		p, err := action.UISizePayload()
+		require.NoError(t, err)
+		assert.Equal(t, 100, p.Height)
+	})
+}
+
+func TestNewToolAction(t *testing.T) {
+	action, err := NewToolAction("msg-123", "get_status", map[string]any{
+		"verbose": true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionTypeTool, action.Type)
+	assert.Equal(t, "msg-123", action.MessageID)
+
+	p, err := action.ToolPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "get_status", p.ToolName)
+	assert.Equal(t, true, p.Params["verbose"])
+}
+
+func TestNewIntentAction(t *testing.T) {
+	action, err := NewIntentAction("msg-456", "change_scene", map[string]any{
+		"scene": "Gaming",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionTypeIntent, action.Type)
+	assert.Equal(t, "msg-456", action.MessageID)
+
+	p, err := action.IntentPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "change_scene", p.Intent)
+	assert.Equal(t, "Gaming", p.Params["scene"])
+}
+
+func TestNewPromptAction(t *testing.T) {
+	action, err := NewPromptAction("msg-789", "How do I configure audio?")
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionTypePrompt, action.Type)
+	assert.Equal(t, "msg-789", action.MessageID)
+
+	p, err := action.PromptPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "How do I configure audio?", p.Prompt)
+}
+
+func TestNewNotifyAction(t *testing.T) {
+	action, err := NewNotifyAction("Stream started!", "info")
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionTypeNotify, action.Type)
+	assert.Empty(t, action.MessageID) // notify doesn't need messageId
+
+	p, err := action.NotifyPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "Stream started!", p.Message)
+	assert.Equal(t, "info", p.Level)
+}
+
+func TestNewLinkAction(t *testing.T) {
+	action, err := NewLinkAction("https://docs.example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionTypeLink, action.Type)
+
+	p, err := action.LinkPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "https://docs.example.com", p.URL)
+}
+
+func TestNewUISizeAction(t *testing.T) {
+	action, err := NewUISizeAction(600, 800)
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionTypeUISize, action.Type)
+
+	p, err := action.UISizePayload()
+	require.NoError(t, err)
+	assert.Equal(t, 600, p.Height)
+	assert.Equal(t, 800, p.Width)
+}
+
+func TestUIAction_JSONRoundTrip(t *testing.T) {
+	original := &UIAction{
+		Type:      ActionTypeTool,
+		MessageID: "test-msg-id",
+		Payload:   json.RawMessage(`{"toolName":"my_tool","params":{"key":"value"}}`),
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded UIAction
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Type, decoded.Type)
+	assert.Equal(t, original.MessageID, decoded.MessageID)
+
+	// Verify payload can be parsed
+	p, err := decoded.ToolPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "my_tool", p.ToolName)
+}
+
+func TestActionTypeConstants(t *testing.T) {
+	// Verify constants match protocol specification
+	assert.Equal(t, "tool", ActionTypeTool)
+	assert.Equal(t, "intent", ActionTypeIntent)
+	assert.Equal(t, "prompt", ActionTypePrompt)
+	assert.Equal(t, "notify", ActionTypeNotify)
+	assert.Equal(t, "link", ActionTypeLink)
+	assert.Equal(t, "ui-size-change", ActionTypeUISize)
+}

--- a/pkg/mcpui/content.go
+++ b/pkg/mcpui/content.go
@@ -1,0 +1,208 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// MIME type constants for UI resources.
+const (
+	MIMETypeHTML      = "text/html"
+	MIMETypeURLList   = "text/uri-list"
+	MIMETypeRemoteDOM = "application/vnd.mcp-ui.remote-dom"
+)
+
+// Framework constants for Remote DOM rendering.
+type Framework string
+
+const (
+	// FrameworkReact specifies React as the rendering framework.
+	FrameworkReact Framework = "react"
+	// FrameworkWebComponents specifies Web Components as the rendering framework.
+	FrameworkWebComponents Framework = "webcomponents"
+)
+
+// URIScheme is the URI scheme for UI resources.
+const URIScheme = "ui://"
+
+// Annotations contains metadata annotations for UI content.
+// This mirrors the annotations concept from the MCP protocol.
+type Annotations struct {
+	// Audience specifies the intended audience for this content.
+	Audience []string `json:"audience,omitempty"`
+	// Priority indicates the relative importance of this content.
+	Priority *float64 `json:"priority,omitempty"`
+}
+
+// UIContent is an [HTMLContent], [URLContent], or [RemoteDOMContent].
+// This interface mirrors mcp.Content for UI resources.
+type UIContent interface {
+	// MarshalJSON serializes the content to JSON wire format.
+	MarshalJSON() ([]byte, error)
+	// mimeType returns the MIME type for this content.
+	mimeType() string
+	// fromWire populates the content from wire format.
+	fromWire(*wireUIContent)
+}
+
+// HTMLContent contains inline HTML to render in a sandboxed iframe.
+// The HTML is rendered using the iframe's srcdoc attribute.
+type HTMLContent struct {
+	// HTML is the inline HTML content to render.
+	HTML string
+	// Annotations contains optional metadata.
+	Annotations *Annotations
+}
+
+// MarshalJSON serializes HTMLContent to the wire format.
+func (c *HTMLContent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&wireUIContent{
+		MIMEType:    MIMETypeHTML,
+		Text:        c.HTML,
+		Annotations: c.Annotations,
+	})
+}
+
+func (c *HTMLContent) mimeType() string { return MIMETypeHTML }
+
+func (c *HTMLContent) fromWire(wire *wireUIContent) {
+	c.HTML = wire.Text
+	c.Annotations = wire.Annotations
+}
+
+// URLContent contains an external URL to render in an iframe.
+// The URL is loaded using the iframe's src attribute.
+type URLContent struct {
+	// URL is the external URL to load.
+	URL string
+	// Annotations contains optional metadata.
+	Annotations *Annotations
+}
+
+// MarshalJSON serializes URLContent to the wire format.
+func (c *URLContent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&wireUIContent{
+		MIMEType:    MIMETypeURLList,
+		Text:        c.URL,
+		Annotations: c.Annotations,
+	})
+}
+
+func (c *URLContent) mimeType() string { return MIMETypeURLList }
+
+func (c *URLContent) fromWire(wire *wireUIContent) {
+	c.URL = wire.Text
+	c.Annotations = wire.Annotations
+}
+
+// RemoteDOMContent contains a script for remote DOM rendering.
+// The script is executed in a Web Worker inside a sandboxed iframe,
+// and DOM changes are communicated to the host via JSON messages.
+type RemoteDOMContent struct {
+	// Script is the JavaScript code that constructs the remote DOM.
+	Script string
+	// Framework specifies the rendering framework (React or WebComponents).
+	Framework Framework
+	// Annotations contains optional metadata.
+	Annotations *Annotations
+}
+
+// MarshalJSON serializes RemoteDOMContent to the wire format.
+func (c *RemoteDOMContent) MarshalJSON() ([]byte, error) {
+	mimeType := MIMETypeRemoteDOM + "+javascript"
+	if c.Framework != "" {
+		mimeType += "; framework=" + string(c.Framework)
+	}
+	return json.Marshal(&wireUIContent{
+		MIMEType:    mimeType,
+		Text:        c.Script,
+		Annotations: c.Annotations,
+	})
+}
+
+func (c *RemoteDOMContent) mimeType() string {
+	mimeType := MIMETypeRemoteDOM + "+javascript"
+	if c.Framework != "" {
+		mimeType += "; framework=" + string(c.Framework)
+	}
+	return mimeType
+}
+
+func (c *RemoteDOMContent) fromWire(wire *wireUIContent) {
+	c.Script = wire.Text
+	c.Annotations = wire.Annotations
+	// Framework is parsed from the MIME type if needed
+}
+
+// BlobContent contains binary data (base64-encoded) for UI resources.
+// This is used for images, fonts, or other binary assets.
+type BlobContent struct {
+	// Data is the binary content.
+	Data []byte
+	// MIMEType is the MIME type of the binary content.
+	ContentMIMEType string
+	// Annotations contains optional metadata.
+	Annotations *Annotations
+}
+
+// MarshalJSON serializes BlobContent to the wire format.
+func (c *BlobContent) MarshalJSON() ([]byte, error) {
+	encoded := base64.StdEncoding.EncodeToString(c.Data)
+	return json.Marshal(&wireUIContent{
+		MIMEType:    c.ContentMIMEType,
+		Blob:        encoded,
+		Annotations: c.Annotations,
+	})
+}
+
+func (c *BlobContent) mimeType() string { return c.ContentMIMEType }
+
+func (c *BlobContent) fromWire(wire *wireUIContent) {
+	if wire.Blob != "" {
+		c.Data, _ = base64.StdEncoding.DecodeString(wire.Blob)
+	}
+	c.ContentMIMEType = wire.MIMEType
+	c.Annotations = wire.Annotations
+}
+
+// wireUIContent is the wire format for UI content.
+// It represents all content types in a single structure for JSON marshaling.
+type wireUIContent struct {
+	MIMEType    string       `json:"mimeType"`
+	Text        string       `json:"text,omitempty"`
+	Blob        string       `json:"blob,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+}
+
+// ContentFromWire converts wire format to the appropriate UIContent type.
+func ContentFromWire(wire *wireUIContent) (UIContent, error) {
+	if wire == nil {
+		return nil, fmt.Errorf("nil wire content")
+	}
+
+	switch {
+	case wire.MIMEType == MIMETypeHTML:
+		c := &HTMLContent{}
+		c.fromWire(wire)
+		return c, nil
+	case wire.MIMEType == MIMETypeURLList:
+		c := &URLContent{}
+		c.fromWire(wire)
+		return c, nil
+	case len(wire.MIMEType) >= len(MIMETypeRemoteDOM) && wire.MIMEType[:len(MIMETypeRemoteDOM)] == MIMETypeRemoteDOM:
+		c := &RemoteDOMContent{}
+		c.fromWire(wire)
+		return c, nil
+	case wire.Blob != "":
+		c := &BlobContent{}
+		c.fromWire(wire)
+		return c, nil
+	default:
+		return nil, fmt.Errorf("unknown content MIME type: %s", wire.MIMEType)
+	}
+}

--- a/pkg/mcpui/content_test.go
+++ b/pkg/mcpui/content_test.go
@@ -1,0 +1,346 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTMLContent_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  *HTMLContent
+		wantJSON map[string]any
+	}{
+		{
+			name: "simple HTML",
+			content: &HTMLContent{
+				HTML: "<div>Hello</div>",
+			},
+			wantJSON: map[string]any{
+				"mimeType": "text/html",
+				"text":     "<div>Hello</div>",
+			},
+		},
+		{
+			name: "HTML with annotations",
+			content: &HTMLContent{
+				HTML: "<p>Test</p>",
+				Annotations: &Annotations{
+					Audience: []string{"user"},
+				},
+			},
+			wantJSON: map[string]any{
+				"mimeType": "text/html",
+				"text":     "<p>Test</p>",
+				"annotations": map[string]any{
+					"audience": []any{"user"},
+				},
+			},
+		},
+		{
+			name: "empty HTML",
+			content: &HTMLContent{
+				HTML: "",
+			},
+			wantJSON: map[string]any{
+				"mimeType": "text/html",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.content.MarshalJSON()
+			require.NoError(t, err)
+
+			var gotMap map[string]any
+			err = json.Unmarshal(got, &gotMap)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantJSON["mimeType"], gotMap["mimeType"])
+			if tt.wantJSON["text"] != nil {
+				assert.Equal(t, tt.wantJSON["text"], gotMap["text"])
+			}
+		})
+	}
+}
+
+func TestURLContent_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  *URLContent
+		wantJSON map[string]any
+	}{
+		{
+			name: "simple URL",
+			content: &URLContent{
+				URL: "https://example.com",
+			},
+			wantJSON: map[string]any{
+				"mimeType": "text/uri-list",
+				"text":     "https://example.com",
+			},
+		},
+		{
+			name: "URL with path",
+			content: &URLContent{
+				URL: "https://example.com/dashboard?tab=settings",
+			},
+			wantJSON: map[string]any{
+				"mimeType": "text/uri-list",
+				"text":     "https://example.com/dashboard?tab=settings",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.content.MarshalJSON()
+			require.NoError(t, err)
+
+			var gotMap map[string]any
+			err = json.Unmarshal(got, &gotMap)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantJSON["mimeType"], gotMap["mimeType"])
+			assert.Equal(t, tt.wantJSON["text"], gotMap["text"])
+		})
+	}
+}
+
+func TestRemoteDOMContent_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      *RemoteDOMContent
+		wantMIMEType string
+	}{
+		{
+			name: "without framework",
+			content: &RemoteDOMContent{
+				Script: "console.log('hello');",
+			},
+			wantMIMEType: "application/vnd.mcp-ui.remote-dom+javascript",
+		},
+		{
+			name: "with React framework",
+			content: &RemoteDOMContent{
+				Script:    "React.createElement('div', null, 'Hello');",
+				Framework: FrameworkReact,
+			},
+			wantMIMEType: "application/vnd.mcp-ui.remote-dom+javascript; framework=react",
+		},
+		{
+			name: "with WebComponents framework",
+			content: &RemoteDOMContent{
+				Script:    "customElements.define('my-component', MyComponent);",
+				Framework: FrameworkWebComponents,
+			},
+			wantMIMEType: "application/vnd.mcp-ui.remote-dom+javascript; framework=webcomponents",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.content.MarshalJSON()
+			require.NoError(t, err)
+
+			var gotMap map[string]any
+			err = json.Unmarshal(got, &gotMap)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantMIMEType, gotMap["mimeType"])
+			assert.Equal(t, tt.content.Script, gotMap["text"])
+		})
+	}
+}
+
+func TestBlobContent_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    *BlobContent
+		wantBlob   string
+		blobOmited bool // true if blob should be omitted from JSON
+	}{
+		{
+			name: "binary data",
+			content: &BlobContent{
+				Data:            []byte{0x89, 0x50, 0x4E, 0x47}, // PNG magic bytes
+				ContentMIMEType: "image/png",
+			},
+			wantBlob: "iVBORw==", // base64 of the bytes
+		},
+		{
+			name: "empty data",
+			content: &BlobContent{
+				Data:            []byte{},
+				ContentMIMEType: "application/octet-stream",
+			},
+			blobOmited: true, // empty string is omitted by omitempty
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.content.MarshalJSON()
+			require.NoError(t, err)
+
+			var gotMap map[string]any
+			err = json.Unmarshal(got, &gotMap)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.content.ContentMIMEType, gotMap["mimeType"])
+			if tt.blobOmited {
+				_, exists := gotMap["blob"]
+				assert.False(t, exists, "blob should be omitted for empty data")
+			} else {
+				assert.Equal(t, tt.wantBlob, gotMap["blob"])
+			}
+		})
+	}
+}
+
+func TestContentFromWire(t *testing.T) {
+	tests := []struct {
+		name    string
+		wire    *wireUIContent
+		wantErr bool
+		check   func(t *testing.T, c UIContent)
+	}{
+		{
+			name: "HTML content",
+			wire: &wireUIContent{
+				MIMEType: MIMETypeHTML,
+				Text:     "<div>Test</div>",
+			},
+			check: func(t *testing.T, c UIContent) {
+				html, ok := c.(*HTMLContent)
+				require.True(t, ok, "expected HTMLContent")
+				assert.Equal(t, "<div>Test</div>", html.HTML)
+			},
+		},
+		{
+			name: "URL content",
+			wire: &wireUIContent{
+				MIMEType: MIMETypeURLList,
+				Text:     "https://example.com",
+			},
+			check: func(t *testing.T, c UIContent) {
+				url, ok := c.(*URLContent)
+				require.True(t, ok, "expected URLContent")
+				assert.Equal(t, "https://example.com", url.URL)
+			},
+		},
+		{
+			name: "RemoteDOM content",
+			wire: &wireUIContent{
+				MIMEType: MIMETypeRemoteDOM + "+javascript",
+				Text:     "console.log('test');",
+			},
+			check: func(t *testing.T, c UIContent) {
+				dom, ok := c.(*RemoteDOMContent)
+				require.True(t, ok, "expected RemoteDOMContent")
+				assert.Equal(t, "console.log('test');", dom.Script)
+			},
+		},
+		{
+			name: "RemoteDOM with framework",
+			wire: &wireUIContent{
+				MIMEType: MIMETypeRemoteDOM + "+javascript; framework=react",
+				Text:     "React.render();",
+			},
+			check: func(t *testing.T, c UIContent) {
+				dom, ok := c.(*RemoteDOMContent)
+				require.True(t, ok, "expected RemoteDOMContent")
+				assert.Equal(t, "React.render();", dom.Script)
+			},
+		},
+		{
+			name: "Blob content",
+			wire: &wireUIContent{
+				MIMEType: "image/png",
+				Blob:     "iVBORw==",
+			},
+			check: func(t *testing.T, c UIContent) {
+				blob, ok := c.(*BlobContent)
+				require.True(t, ok, "expected BlobContent")
+				assert.Equal(t, "image/png", blob.ContentMIMEType)
+				assert.Equal(t, []byte{0x89, 0x50, 0x4E, 0x47}, blob.Data)
+			},
+		},
+		{
+			name:    "nil wire",
+			wire:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ContentFromWire(tt.wire)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestHTMLContent_MimeType(t *testing.T) {
+	c := &HTMLContent{HTML: "<div>Test</div>"}
+	assert.Equal(t, MIMETypeHTML, c.mimeType())
+}
+
+func TestURLContent_MimeType(t *testing.T) {
+	c := &URLContent{URL: "https://example.com"}
+	assert.Equal(t, MIMETypeURLList, c.mimeType())
+}
+
+func TestRemoteDOMContent_MimeType(t *testing.T) {
+	tests := []struct {
+		name      string
+		framework Framework
+		want      string
+	}{
+		{
+			name:      "no framework",
+			framework: "",
+			want:      "application/vnd.mcp-ui.remote-dom+javascript",
+		},
+		{
+			name:      "react",
+			framework: FrameworkReact,
+			want:      "application/vnd.mcp-ui.remote-dom+javascript; framework=react",
+		},
+		{
+			name:      "webcomponents",
+			framework: FrameworkWebComponents,
+			want:      "application/vnd.mcp-ui.remote-dom+javascript; framework=webcomponents",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &RemoteDOMContent{Script: "test", Framework: tt.framework}
+			assert.Equal(t, tt.want, c.mimeType())
+		})
+	}
+}
+
+func TestConstants(t *testing.T) {
+	// Verify constants match MCP-UI specification
+	assert.Equal(t, "text/html", MIMETypeHTML)
+	assert.Equal(t, "text/uri-list", MIMETypeURLList)
+	assert.Equal(t, "application/vnd.mcp-ui.remote-dom", MIMETypeRemoteDOM)
+	assert.Equal(t, "ui://", URIScheme)
+	assert.Equal(t, Framework("react"), FrameworkReact)
+	assert.Equal(t, Framework("webcomponents"), FrameworkWebComponents)
+}

--- a/pkg/mcpui/doc.go
+++ b/pkg/mcpui/doc.go
@@ -1,0 +1,92 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// Package mcpui provides a Go SDK for the MCP-UI protocol (SEP-1865).
+//
+// MCP-UI enables MCP servers to return interactive UI resources that clients
+// can render in sandboxed iframes. This package implements the server-side
+// portion of the protocol, allowing Go-based MCP servers to generate UI
+// resources.
+//
+// # Overview
+//
+// The MCP-UI protocol defines three types of UI content:
+//
+//   - [HTMLContent]: Inline HTML rendered via iframe srcdoc
+//   - [URLContent]: External URL rendered via iframe src
+//   - [RemoteDOMContent]: Script-based UI using remote DOM rendering
+//
+// Each content type implements the [UIContent] interface and can be serialized
+// to JSON for transmission to clients.
+//
+// # Creating UI Resources
+//
+// To create a simple HTML UI resource:
+//
+//	resource := &mcpui.UIResource{
+//		URI:  "ui://hello/greeting",
+//		Name: "Greeting Card",
+//		Content: &mcpui.HTMLContent{
+//			HTML: `<div style="padding: 20px;">Hello, World!</div>`,
+//		},
+//	}
+//
+// To create an external URL resource:
+//
+//	resource := &mcpui.UIResource{
+//		URI:  "ui://dashboard/main",
+//		Name: "Dashboard",
+//		Content: &mcpui.URLContent{
+//			URL: "https://example.com/dashboard",
+//		},
+//	}
+//
+// # Handling UI Actions
+//
+// When users interact with UI resources, the client sends [UIAction] messages.
+// Use [UIActionHandler] to process these actions:
+//
+//	handler := func(ctx context.Context, req *mcpui.UIActionRequest) (*mcpui.UIActionResult, error) {
+//		switch req.Action.Type {
+//		case mcpui.ActionTypeTool:
+//			var payload mcpui.ToolActionPayload
+//			if err := json.Unmarshal(req.Action.Payload, &payload); err != nil {
+//				return nil, err
+//			}
+//			// Handle tool call...
+//		}
+//		return &mcpui.UIActionResult{Response: "OK"}, nil
+//	}
+//
+// # Response Messages
+//
+// Send responses back to the UI using the response builders:
+//
+//	// Acknowledge receipt
+//	ack := mcpui.NewReceivedResponse(action.MessageID)
+//
+//	// Send success response
+//	resp := mcpui.NewSuccessResponse(action.MessageID, result)
+//
+//	// Send error response
+//	errResp := mcpui.NewErrorResponse(action.MessageID, err)
+//
+// # Protocol Details
+//
+// The MCP-UI protocol is documented at https://mcpui.dev/. This SDK implements
+// the server-side portion, enabling Go-based MCP servers to generate UI
+// resources that compliant clients can render.
+//
+// MIME types used by the protocol:
+//
+//   - text/html: Inline HTML content
+//   - text/uri-list: External URL content
+//   - application/vnd.mcp-ui.remote-dom: Remote DOM script content
+//
+// # Integration with MCP
+//
+// This package is designed to work alongside the official MCP Go SDK
+// (github.com/modelcontextprotocol/go-sdk). UI resources can be returned
+// from MCP tool handlers as additional content alongside regular tool results.
+package mcpui

--- a/pkg/mcpui/example_test.go
+++ b/pkg/mcpui/example_test.go
@@ -1,0 +1,250 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ironystock/agentic-obs/pkg/mcpui"
+)
+
+// ExampleHTMLContent demonstrates creating HTML content for a UI resource.
+func ExampleHTMLContent() {
+	content := &mcpui.HTMLContent{
+		HTML: "<div>Hello, World!</div>",
+	}
+
+	data, _ := content.MarshalJSON()
+
+	// Parse to verify structure
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	fmt.Printf("mimeType: %s\n", m["mimeType"])
+	fmt.Printf("has text: %v\n", m["text"] != nil)
+	// Output:
+	// mimeType: text/html
+	// has text: true
+}
+
+// ExampleURLContent demonstrates creating URL content for an external resource.
+func ExampleURLContent() {
+	content := &mcpui.URLContent{
+		URL: "https://example.com/dashboard",
+	}
+
+	data, _ := content.MarshalJSON()
+	fmt.Println(string(data))
+	// Output: {"mimeType":"text/uri-list","text":"https://example.com/dashboard"}
+}
+
+// ExampleRemoteDOMContent demonstrates creating Remote DOM content with React.
+func ExampleRemoteDOMContent() {
+	content := &mcpui.RemoteDOMContent{
+		Script:    "React.createElement('div', null, 'Hello from React!');",
+		Framework: mcpui.FrameworkReact,
+	}
+
+	data, _ := content.MarshalJSON()
+	fmt.Println(string(data))
+	// Output: {"mimeType":"application/vnd.mcp-ui.remote-dom+javascript; framework=react","text":"React.createElement('div', null, 'Hello from React!');"}
+}
+
+// ExampleUIResource demonstrates creating a UI resource definition.
+func ExampleUIResource() {
+	resource := &mcpui.UIResource{
+		URI:         "ui://dashboard/main",
+		Name:        "main-dashboard",
+		Title:       "Main Dashboard",
+		Description: "The primary dashboard view for monitoring",
+		MIMEType:    mcpui.MIMETypeHTML,
+	}
+
+	if err := resource.Validate(); err != nil {
+		fmt.Println("Invalid:", err)
+		return
+	}
+
+	data, _ := json.Marshal(resource)
+	fmt.Println(string(data))
+	// Output: {"uri":"ui://dashboard/main","name":"main-dashboard","title":"Main Dashboard","description":"The primary dashboard view for monitoring","mimeType":"text/html"}
+}
+
+// ExampleNewUIResourceContents demonstrates creating resource contents from content.
+func ExampleNewUIResourceContents() {
+	content := &mcpui.HTMLContent{
+		HTML: "<p>Hello</p>",
+	}
+
+	rc, err := mcpui.NewUIResourceContents("ui://greeting/hello", content)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Printf("URI: %s, MIME: %s\n", rc.URI, rc.MIMEType)
+	// Output: URI: ui://greeting/hello, MIME: text/html
+}
+
+// ExampleUIAction_ParsePayload demonstrates parsing action payloads.
+func ExampleUIAction_ParsePayload() {
+	action := &mcpui.UIAction{
+		Type:      mcpui.ActionTypeTool,
+		MessageID: "msg-123",
+		Payload:   json.RawMessage(`{"toolName":"get_status","params":{"verbose":true}}`),
+	}
+
+	payload, err := action.ParsePayload()
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	toolPayload := payload.(*mcpui.ToolActionPayload)
+	fmt.Printf("Tool: %s, Verbose: %v\n", toolPayload.ToolName, toolPayload.Params["verbose"])
+	// Output: Tool: get_status, Verbose: true
+}
+
+// ExampleNewToolAction demonstrates creating a tool action.
+func ExampleNewToolAction() {
+	action, err := mcpui.NewToolAction("msg-456", "set_volume", map[string]any{
+		"source": "Microphone",
+		"level":  0.8,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	data, _ := json.Marshal(action)
+	fmt.Println(string(data))
+	// Output: {"type":"tool","messageId":"msg-456","payload":{"toolName":"set_volume","params":{"level":0.8,"source":"Microphone"}}}
+}
+
+// ExampleNewReceivedResponse demonstrates creating an acknowledgment response.
+func ExampleNewReceivedResponse() {
+	resp := mcpui.NewReceivedResponse("msg-123")
+
+	data, _ := json.Marshal(resp)
+	fmt.Println(string(data))
+	// Output: {"type":"ui-message-received","messageId":"msg-123"}
+}
+
+// ExampleNewSuccessResponse demonstrates creating a success response.
+func ExampleNewSuccessResponse() {
+	result := map[string]any{
+		"status": "ok",
+		"volume": 0.8,
+	}
+	resp := mcpui.NewSuccessResponse("msg-456", result)
+
+	fmt.Printf("Success: %v, Response: %v\n", resp.IsSuccess(), resp.GetResponse() != nil)
+	// Output: Success: true, Response: true
+}
+
+// ExampleNewErrorResponse demonstrates creating an error response.
+func ExampleNewErrorResponse() {
+	resp := mcpui.NewErrorResponse("msg-789", fmt.Errorf("source not found"))
+
+	fmt.Printf("Error: %v, Message: %s\n", resp.IsError(), resp.GetError().Message)
+	// Output: Error: true, Message: source not found
+}
+
+// ExampleRouter demonstrates using the action router.
+func ExampleRouter() {
+	router := mcpui.NewRouter()
+
+	// Register handler for tool actions
+	router.HandleType(mcpui.ActionTypeTool, mcpui.WrapToolHandler(
+		func(ctx context.Context, toolName string, params map[string]any) (any, error) {
+			return map[string]string{"executed": toolName}, nil
+		},
+	))
+
+	// Register handler for a specific resource
+	router.HandleResource("ui://dashboard/main", func(ctx context.Context, req *mcpui.UIActionRequest) (*mcpui.UIActionResult, error) {
+		return &mcpui.UIActionResult{Response: "dashboard action handled"}, nil
+	})
+
+	// Create and dispatch an action
+	action, _ := mcpui.NewToolAction("msg-1", "get_status", nil)
+	req := &mcpui.UIActionRequest{Action: action}
+
+	result, err := router.Dispatch(context.Background(), req)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("Result:", result.Response)
+	// Output: Result: map[executed:get_status]
+}
+
+// ExampleWrapToolHandler demonstrates wrapping a tool handler.
+func ExampleWrapToolHandler() {
+	handler := mcpui.WrapToolHandler(func(ctx context.Context, toolName string, params map[string]any) (any, error) {
+		switch toolName {
+		case "greet":
+			name := params["name"].(string)
+			return fmt.Sprintf("Hello, %s!", name), nil
+		default:
+			return nil, fmt.Errorf("unknown tool: %s", toolName)
+		}
+	})
+
+	action, _ := mcpui.NewToolAction("msg-1", "greet", map[string]any{"name": "World"})
+	req := &mcpui.UIActionRequest{Action: action}
+
+	result, _ := handler(context.Background(), req)
+	fmt.Println(result.Response)
+	// Output: Hello, World!
+}
+
+// Example demonstrates a complete workflow of creating and handling UI resources.
+func Example() {
+	// 1. Create a UI resource
+	resource := &mcpui.UIResource{
+		URI:      "ui://greeting/welcome",
+		Name:     "welcome",
+		Title:    "Welcome Card",
+		MIMEType: mcpui.MIMETypeHTML,
+	}
+
+	// 2. Create content for the resource
+	content := &mcpui.HTMLContent{
+		HTML: "<h1>Welcome!</h1><button onclick=\"sendAction()\">Click Me</button>",
+	}
+
+	// 3. Create resource contents
+	rc, _ := mcpui.NewUIResourceContents(resource.URI, content)
+
+	// 4. Set up a router to handle actions
+	router := mcpui.NewRouter()
+	router.HandleType(mcpui.ActionTypeTool, mcpui.WrapToolHandler(
+		func(ctx context.Context, toolName string, params map[string]any) (any, error) {
+			return "Tool executed: " + toolName, nil
+		},
+	))
+
+	// 5. Simulate receiving an action from the UI
+	action, _ := mcpui.NewToolAction("msg-1", "button_clicked", nil)
+	req := &mcpui.UIActionRequest{
+		Action:      action,
+		ResourceURI: resource.URI,
+	}
+
+	// 6. Handle the action and create response
+	result, _ := router.Dispatch(context.Background(), req)
+	resp := result.ToUIResponse(action.MessageID)
+
+	fmt.Printf("Resource: %s\n", rc.URI)
+	fmt.Printf("Response type: %s\n", resp.Type)
+	fmt.Printf("Success: %v\n", resp.IsSuccess())
+	// Output:
+	// Resource: ui://greeting/welcome
+	// Response type: ui-message-response
+	// Success: true
+}

--- a/pkg/mcpui/handler.go
+++ b/pkg/mcpui/handler.go
@@ -1,0 +1,247 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// UIActionHandler handles UI actions from embedded resources.
+// This follows the pattern of mcp.ResourceHandler and mcp.ToolHandler.
+type UIActionHandler func(context.Context, *UIActionRequest) (*UIActionResult, error)
+
+// UIActionRequest contains the action and session context.
+type UIActionRequest struct {
+	// Action is the UI action to process.
+	Action *UIAction
+	// ResourceURI is the URI of the resource that triggered the action.
+	ResourceURI string
+	// Session can hold session-specific data (e.g., mcp.ServerSession).
+	Session any
+}
+
+// UIActionResult is the result of handling a UI action.
+type UIActionResult struct {
+	// Response contains the successful result data.
+	Response any
+	// Error contains error information if the action failed.
+	Error error
+}
+
+// ToUIResponse converts the result to a UIResponse.
+func (r *UIActionResult) ToUIResponse(messageID string) *UIResponse {
+	if r.Error != nil {
+		return NewErrorResponse(messageID, r.Error)
+	}
+	return NewSuccessResponse(messageID, r.Response)
+}
+
+// Router dispatches UI actions to appropriate handlers.
+// It provides a way to register handlers for different action types and resources.
+type Router struct {
+	mu sync.RWMutex
+	// handlers by action type
+	typeHandlers map[string]UIActionHandler
+	// handlers by resource URI pattern
+	resourceHandlers map[string]UIActionHandler
+	// default handler for unmatched actions
+	defaultHandler UIActionHandler
+}
+
+// NewRouter creates a new Router.
+func NewRouter() *Router {
+	return &Router{
+		typeHandlers:     make(map[string]UIActionHandler),
+		resourceHandlers: make(map[string]UIActionHandler),
+	}
+}
+
+// HandleType registers a handler for a specific action type.
+func (r *Router) HandleType(actionType string, handler UIActionHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.typeHandlers[actionType] = handler
+}
+
+// HandleResource registers a handler for a specific resource URI.
+func (r *Router) HandleResource(resourceURI string, handler UIActionHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.resourceHandlers[resourceURI] = handler
+}
+
+// SetDefault sets the default handler for unmatched actions.
+func (r *Router) SetDefault(handler UIActionHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.defaultHandler = handler
+}
+
+// Dispatch routes an action to the appropriate handler.
+// Priority order:
+// 1. Resource-specific handler (exact URI match)
+// 2. Action type handler
+// 3. Default handler
+func (r *Router) Dispatch(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// Check for resource-specific handler first
+	if req.ResourceURI != "" {
+		if handler, ok := r.resourceHandlers[req.ResourceURI]; ok {
+			return handler(ctx, req)
+		}
+	}
+
+	// Check for action type handler
+	if req.Action != nil {
+		if handler, ok := r.typeHandlers[req.Action.Type]; ok {
+			return handler(ctx, req)
+		}
+	}
+
+	// Fall back to default handler
+	if r.defaultHandler != nil {
+		return r.defaultHandler(ctx, req)
+	}
+
+	return nil, fmt.Errorf("no handler for action type %q from resource %q", req.Action.Type, req.ResourceURI)
+}
+
+// Handle implements the UIActionHandler interface, making Router itself a handler.
+func (r *Router) Handle(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+	return r.Dispatch(ctx, req)
+}
+
+// ToolHandler is a convenience type for handling tool actions.
+// It is called when an embedded UI requests a tool execution.
+type ToolHandler func(ctx context.Context, toolName string, params map[string]any) (any, error)
+
+// WrapToolHandler wraps a ToolHandler as a UIActionHandler.
+func WrapToolHandler(handler ToolHandler) UIActionHandler {
+	return func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		if req.Action.Type != ActionTypeTool {
+			return nil, fmt.Errorf("expected tool action, got %s", req.Action.Type)
+		}
+		payload, err := req.Action.ToolPayload()
+		if err != nil {
+			return nil, err
+		}
+		result, err := handler(ctx, payload.ToolName, payload.Params)
+		if err != nil {
+			return &UIActionResult{Error: err}, nil
+		}
+		return &UIActionResult{Response: result}, nil
+	}
+}
+
+// IntentHandler is a convenience type for handling intent actions.
+// It is called when an embedded UI signals a user intent.
+type IntentHandler func(ctx context.Context, intent string, params map[string]any) (any, error)
+
+// WrapIntentHandler wraps an IntentHandler as a UIActionHandler.
+func WrapIntentHandler(handler IntentHandler) UIActionHandler {
+	return func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		if req.Action.Type != ActionTypeIntent {
+			return nil, fmt.Errorf("expected intent action, got %s", req.Action.Type)
+		}
+		payload, err := req.Action.IntentPayload()
+		if err != nil {
+			return nil, err
+		}
+		result, err := handler(ctx, payload.Intent, payload.Params)
+		if err != nil {
+			return &UIActionResult{Error: err}, nil
+		}
+		return &UIActionResult{Response: result}, nil
+	}
+}
+
+// PromptHandler is a convenience type for handling prompt actions.
+// It is called when an embedded UI sends a prompt message.
+type PromptHandler func(ctx context.Context, prompt string) (any, error)
+
+// WrapPromptHandler wraps a PromptHandler as a UIActionHandler.
+func WrapPromptHandler(handler PromptHandler) UIActionHandler {
+	return func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		if req.Action.Type != ActionTypePrompt {
+			return nil, fmt.Errorf("expected prompt action, got %s", req.Action.Type)
+		}
+		payload, err := req.Action.PromptPayload()
+		if err != nil {
+			return nil, err
+		}
+		result, err := handler(ctx, payload.Prompt)
+		if err != nil {
+			return &UIActionResult{Error: err}, nil
+		}
+		return &UIActionResult{Response: result}, nil
+	}
+}
+
+// NotifyHandler is a convenience type for handling notify actions.
+// It is called when an embedded UI sends a notification.
+type NotifyHandler func(ctx context.Context, message string, level string) error
+
+// WrapNotifyHandler wraps a NotifyHandler as a UIActionHandler.
+func WrapNotifyHandler(handler NotifyHandler) UIActionHandler {
+	return func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		if req.Action.Type != ActionTypeNotify {
+			return nil, fmt.Errorf("expected notify action, got %s", req.Action.Type)
+		}
+		payload, err := req.Action.NotifyPayload()
+		if err != nil {
+			return nil, err
+		}
+		if err := handler(ctx, payload.Message, payload.Level); err != nil {
+			return &UIActionResult{Error: err}, nil
+		}
+		return &UIActionResult{Response: "acknowledged"}, nil
+	}
+}
+
+// LinkHandler is a convenience type for handling link actions.
+// It is called when an embedded UI requests to open a link.
+type LinkHandler func(ctx context.Context, url string) error
+
+// WrapLinkHandler wraps a LinkHandler as a UIActionHandler.
+func WrapLinkHandler(handler LinkHandler) UIActionHandler {
+	return func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		if req.Action.Type != ActionTypeLink {
+			return nil, fmt.Errorf("expected link action, got %s", req.Action.Type)
+		}
+		payload, err := req.Action.LinkPayload()
+		if err != nil {
+			return nil, err
+		}
+		if err := handler(ctx, payload.URL); err != nil {
+			return &UIActionResult{Error: err}, nil
+		}
+		return &UIActionResult{Response: "opened"}, nil
+	}
+}
+
+// UISizeHandler is a convenience type for handling UI size change actions.
+// It is called when an embedded UI reports a size change.
+type UISizeHandler func(ctx context.Context, height, width int) error
+
+// WrapUISizeHandler wraps a UISizeHandler as a UIActionHandler.
+func WrapUISizeHandler(handler UISizeHandler) UIActionHandler {
+	return func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		if req.Action.Type != ActionTypeUISize {
+			return nil, fmt.Errorf("expected ui-size-change action, got %s", req.Action.Type)
+		}
+		payload, err := req.Action.UISizePayload()
+		if err != nil {
+			return nil, err
+		}
+		if err := handler(ctx, payload.Height, payload.Width); err != nil {
+			return &UIActionResult{Error: err}, nil
+		}
+		return &UIActionResult{Response: "acknowledged"}, nil
+	}
+}

--- a/pkg/mcpui/handler_test.go
+++ b/pkg/mcpui/handler_test.go
@@ -1,0 +1,295 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIActionResult_ToUIResponse(t *testing.T) {
+	t.Run("success result", func(t *testing.T) {
+		result := &UIActionResult{Response: "success data"}
+		resp := result.ToUIResponse("msg-123")
+
+		assert.Equal(t, ResponseTypeResponse, resp.Type)
+		assert.Equal(t, "msg-123", resp.MessageID)
+		assert.True(t, resp.IsSuccess())
+		assert.Equal(t, "success data", resp.GetResponse())
+	})
+
+	t.Run("error result", func(t *testing.T) {
+		result := &UIActionResult{Error: errors.New("something failed")}
+		resp := result.ToUIResponse("msg-456")
+
+		assert.Equal(t, ResponseTypeResponse, resp.Type)
+		assert.Equal(t, "msg-456", resp.MessageID)
+		assert.True(t, resp.IsError())
+		assert.Equal(t, "something failed", resp.GetError().Message)
+	})
+}
+
+func TestRouter_HandleType(t *testing.T) {
+	router := NewRouter()
+
+	var called bool
+	router.HandleType(ActionTypeTool, func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		called = true
+		return &UIActionResult{Response: "tool handled"}, nil
+	})
+
+	action, _ := NewToolAction("msg-1", "test_tool", nil)
+	req := &UIActionRequest{Action: action}
+
+	result, err := router.Dispatch(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "tool handled", result.Response)
+}
+
+func TestRouter_HandleResource(t *testing.T) {
+	router := NewRouter()
+
+	var called bool
+	router.HandleResource("ui://dashboard/main", func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		called = true
+		return &UIActionResult{Response: "resource handled"}, nil
+	})
+
+	action, _ := NewToolAction("msg-1", "test_tool", nil)
+	req := &UIActionRequest{
+		Action:      action,
+		ResourceURI: "ui://dashboard/main",
+	}
+
+	result, err := router.Dispatch(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "resource handled", result.Response)
+}
+
+func TestRouter_Priority(t *testing.T) {
+	router := NewRouter()
+
+	// Register handlers in reverse priority order
+	router.SetDefault(func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		return &UIActionResult{Response: "default"}, nil
+	})
+	router.HandleType(ActionTypeTool, func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		return &UIActionResult{Response: "type"}, nil
+	})
+	router.HandleResource("ui://test", func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		return &UIActionResult{Response: "resource"}, nil
+	})
+
+	action, _ := NewToolAction("msg-1", "test", nil)
+
+	t.Run("resource takes priority", func(t *testing.T) {
+		req := &UIActionRequest{
+			Action:      action,
+			ResourceURI: "ui://test",
+		}
+		result, err := router.Dispatch(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, "resource", result.Response)
+	})
+
+	t.Run("type handler when no resource match", func(t *testing.T) {
+		req := &UIActionRequest{
+			Action:      action,
+			ResourceURI: "ui://other",
+		}
+		result, err := router.Dispatch(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, "type", result.Response)
+	})
+
+	t.Run("default when no match", func(t *testing.T) {
+		promptAction, _ := NewPromptAction("msg-1", "test")
+		req := &UIActionRequest{
+			Action:      promptAction,
+			ResourceURI: "ui://other",
+		}
+		result, err := router.Dispatch(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, "default", result.Response)
+	})
+}
+
+func TestRouter_NoHandler(t *testing.T) {
+	router := NewRouter()
+
+	action, _ := NewToolAction("msg-1", "test", nil)
+	req := &UIActionRequest{Action: action}
+
+	_, err := router.Dispatch(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no handler")
+}
+
+func TestRouter_Handle(t *testing.T) {
+	router := NewRouter()
+	router.HandleType(ActionTypeTool, func(ctx context.Context, req *UIActionRequest) (*UIActionResult, error) {
+		return &UIActionResult{Response: "handled"}, nil
+	})
+
+	action, _ := NewToolAction("msg-1", "test", nil)
+	req := &UIActionRequest{Action: action}
+
+	// Test that Handle delegates to Dispatch
+	result, err := router.Handle(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "handled", result.Response)
+}
+
+func TestWrapToolHandler(t *testing.T) {
+	handler := WrapToolHandler(func(ctx context.Context, toolName string, params map[string]any) (any, error) {
+		return map[string]string{"tool": toolName}, nil
+	})
+
+	action := &UIAction{
+		Type:    ActionTypeTool,
+		Payload: json.RawMessage(`{"toolName":"my_tool","params":{}}`),
+	}
+	req := &UIActionRequest{Action: action}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"tool": "my_tool"}, result.Response)
+}
+
+func TestWrapToolHandler_WrongType(t *testing.T) {
+	handler := WrapToolHandler(func(ctx context.Context, toolName string, params map[string]any) (any, error) {
+		return nil, nil
+	})
+
+	action, _ := NewPromptAction("msg-1", "test")
+	req := &UIActionRequest{Action: action}
+
+	_, err := handler(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected tool action")
+}
+
+func TestWrapToolHandler_Error(t *testing.T) {
+	handler := WrapToolHandler(func(ctx context.Context, toolName string, params map[string]any) (any, error) {
+		return nil, errors.New("tool failed")
+	})
+
+	action, _ := NewToolAction("msg-1", "test", nil)
+	req := &UIActionRequest{Action: action}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err) // Handler error goes in result, not return error
+	assert.NotNil(t, result.Error)
+	assert.Equal(t, "tool failed", result.Error.Error())
+}
+
+func TestWrapIntentHandler(t *testing.T) {
+	handler := WrapIntentHandler(func(ctx context.Context, intent string, params map[string]any) (any, error) {
+		return map[string]string{"intent": intent}, nil
+	})
+
+	action, _ := NewIntentAction("msg-1", "switch_scene", nil)
+	req := &UIActionRequest{Action: action}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"intent": "switch_scene"}, result.Response)
+}
+
+func TestWrapPromptHandler(t *testing.T) {
+	handler := WrapPromptHandler(func(ctx context.Context, prompt string) (any, error) {
+		return "Got: " + prompt, nil
+	})
+
+	action, _ := NewPromptAction("msg-1", "Hello")
+	req := &UIActionRequest{Action: action}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "Got: Hello", result.Response)
+}
+
+func TestWrapNotifyHandler(t *testing.T) {
+	var receivedMessage, receivedLevel string
+	handler := WrapNotifyHandler(func(ctx context.Context, message string, level string) error {
+		receivedMessage = message
+		receivedLevel = level
+		return nil
+	})
+
+	action, _ := NewNotifyAction("Test notification", "info")
+	req := &UIActionRequest{Action: action}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "acknowledged", result.Response)
+	assert.Equal(t, "Test notification", receivedMessage)
+	assert.Equal(t, "info", receivedLevel)
+}
+
+func TestWrapLinkHandler(t *testing.T) {
+	var receivedURL string
+	handler := WrapLinkHandler(func(ctx context.Context, url string) error {
+		receivedURL = url
+		return nil
+	})
+
+	action, _ := NewLinkAction("https://example.com")
+	req := &UIActionRequest{Action: action}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "opened", result.Response)
+	assert.Equal(t, "https://example.com", receivedURL)
+}
+
+func TestWrapUISizeHandler(t *testing.T) {
+	var receivedHeight, receivedWidth int
+	handler := WrapUISizeHandler(func(ctx context.Context, height, width int) error {
+		receivedHeight = height
+		receivedWidth = width
+		return nil
+	})
+
+	action, _ := NewUISizeAction(600, 800)
+	req := &UIActionRequest{Action: action}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "acknowledged", result.Response)
+	assert.Equal(t, 600, receivedHeight)
+	assert.Equal(t, 800, receivedWidth)
+}
+
+func TestWrappedHandlers_WrongType(t *testing.T) {
+	toolAction, _ := NewToolAction("msg", "test", nil)
+
+	tests := []struct {
+		name    string
+		handler UIActionHandler
+		action  *UIAction
+	}{
+		{"IntentHandler", WrapIntentHandler(func(ctx context.Context, intent string, params map[string]any) (any, error) { return nil, nil }), toolAction},
+		{"PromptHandler", WrapPromptHandler(func(ctx context.Context, prompt string) (any, error) { return nil, nil }), toolAction},
+		{"NotifyHandler", WrapNotifyHandler(func(ctx context.Context, message string, level string) error { return nil }), toolAction},
+		{"LinkHandler", WrapLinkHandler(func(ctx context.Context, url string) error { return nil }), toolAction},
+		{"UISizeHandler", WrapUISizeHandler(func(ctx context.Context, height, width int) error { return nil }), toolAction},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &UIActionRequest{Action: tt.action}
+			_, err := tt.handler(context.Background(), req)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/pkg/mcpui/resource.go
+++ b/pkg/mcpui/resource.go
@@ -1,0 +1,192 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// UIResource represents an interactive UI resource definition.
+// This mirrors mcp.Resource for UI-specific resources.
+// See https://mcpui.dev/guide/protocol-details
+type UIResource struct {
+	// URI is the unique identifier for this resource (e.g., "ui://dashboard/main").
+	URI string `json:"uri"`
+	// Name is intended for programmatic or logical use.
+	Name string `json:"name"`
+	// Title is the human-readable display name.
+	Title string `json:"title,omitempty"`
+	// Description explains what this resource represents.
+	Description string `json:"description,omitempty"`
+	// MIMEType is the MIME type of this resource, if known.
+	MIMEType string `json:"mimeType,omitempty"`
+	// Annotations contains optional metadata.
+	Annotations *Annotations `json:"annotations,omitempty"`
+}
+
+// Validate checks that the UIResource has required fields and valid URI scheme.
+func (r *UIResource) Validate() error {
+	if r.URI == "" {
+		return errors.New("UIResource missing URI")
+	}
+	if !strings.HasPrefix(r.URI, URIScheme) {
+		return errors.New("UIResource URI must start with " + URIScheme)
+	}
+	if r.Name == "" {
+		return errors.New("UIResource missing Name")
+	}
+	return nil
+}
+
+// UIResourceContents contains the contents of a specific UI resource.
+// This mirrors mcp.ResourceContents for UI-specific resources.
+type UIResourceContents struct {
+	// URI is the resource identifier.
+	URI string `json:"uri"`
+	// MIMEType is the content MIME type.
+	MIMEType string `json:"mimeType,omitempty"`
+	// Text is the textual content (HTML, URL, or script).
+	Text string `json:"text,omitempty"`
+	// Blob is the binary content (base64-encoded in JSON).
+	Blob []byte `json:"blob,omitempty"`
+	// Annotations contains optional metadata.
+	Annotations *Annotations `json:"annotations,omitempty"`
+}
+
+// MarshalJSON serializes UIResourceContents to JSON.
+// It follows the mcp.ResourceContents pattern.
+func (r *UIResourceContents) MarshalJSON() ([]byte, error) {
+	if r.URI == "" {
+		return nil, errors.New("UIResourceContents missing URI")
+	}
+	if r.Blob == nil {
+		// Text content. Marshal normally.
+		type wireResourceContents UIResourceContents // lacks MarshalJSON method
+		return json.Marshal((wireResourceContents)(*r))
+	}
+	// Blob content.
+	if r.Text != "" {
+		return nil, errors.New("UIResourceContents has non-zero Text and Blob fields")
+	}
+	// r.Blob may be the empty slice, so marshal with an alternative definition
+	// to ensure "blob" is always included.
+	br := struct {
+		URI         string       `json:"uri,omitempty"`
+		MIMEType    string       `json:"mimeType,omitempty"`
+		Blob        []byte       `json:"blob"`
+		Annotations *Annotations `json:"annotations,omitempty"`
+	}{
+		URI:         r.URI,
+		MIMEType:    r.MIMEType,
+		Blob:        r.Blob,
+		Annotations: r.Annotations,
+	}
+	return json.Marshal(br)
+}
+
+// NewUIResourceContents creates UIResourceContents from a UIContent.
+func NewUIResourceContents(uri string, content UIContent) (*UIResourceContents, error) {
+	if uri == "" {
+		return nil, errors.New("URI is required")
+	}
+	if content == nil {
+		return nil, errors.New("content is required")
+	}
+
+	// Marshal content to wire format to extract fields
+	data, err := content.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	var wire wireUIContent
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, err
+	}
+
+	rc := &UIResourceContents{
+		URI:         uri,
+		MIMEType:    wire.MIMEType,
+		Annotations: wire.Annotations,
+	}
+
+	if wire.Blob != "" {
+		// Decode base64 blob back to bytes
+		var decoded []byte
+		if err := json.Unmarshal([]byte(`"`+wire.Blob+`"`), &decoded); err != nil {
+			// Try direct assignment if not base64
+			rc.Text = wire.Blob
+		} else {
+			rc.Blob = decoded
+		}
+	} else {
+		rc.Text = wire.Text
+	}
+
+	return rc, nil
+}
+
+// ToUIContent converts UIResourceContents back to a UIContent.
+func (r *UIResourceContents) ToUIContent() (UIContent, error) {
+	wire := &wireUIContent{
+		MIMEType:    r.MIMEType,
+		Text:        r.Text,
+		Annotations: r.Annotations,
+	}
+	if r.Blob != nil {
+		// Encode blob to base64 string
+		wire.Blob = string(r.Blob) // Will be properly encoded by ContentFromWire
+	}
+	return ContentFromWire(wire)
+}
+
+// UIResourceTemplate describes a template for UI resources.
+// This mirrors mcp.ResourceTemplate for UI-specific resources.
+type UIResourceTemplate struct {
+	// URITemplate is a URI template following RFC 6570.
+	URITemplate string `json:"uriTemplate"`
+	// Name is intended for programmatic or logical use.
+	Name string `json:"name"`
+	// Title is the human-readable display name.
+	Title string `json:"title,omitempty"`
+	// Description explains what resources this template represents.
+	Description string `json:"description,omitempty"`
+	// MIMEType is the MIME type of resources matching this template.
+	MIMEType string `json:"mimeType,omitempty"`
+	// Annotations contains optional metadata.
+	Annotations *Annotations `json:"annotations,omitempty"`
+}
+
+// Validate checks that the UIResourceTemplate has required fields.
+func (t *UIResourceTemplate) Validate() error {
+	if t.URITemplate == "" {
+		return errors.New("UIResourceTemplate missing URITemplate")
+	}
+	if !strings.HasPrefix(t.URITemplate, URIScheme) {
+		return errors.New("UIResourceTemplate URITemplate must start with " + URIScheme)
+	}
+	if t.Name == "" {
+		return errors.New("UIResourceTemplate missing Name")
+	}
+	return nil
+}
+
+// ReadUIResourceResult is the result of reading a UI resource.
+// This mirrors mcp.ReadResourceResult.
+type ReadUIResourceResult struct {
+	// Contents contains the resource contents.
+	Contents []*UIResourceContents `json:"contents"`
+}
+
+// ListUIResourcesResult is the result of listing UI resources.
+// This mirrors mcp.ListResourcesResult.
+type ListUIResourcesResult struct {
+	// Resources is the list of available UI resources.
+	Resources []*UIResource `json:"resources"`
+	// NextCursor is an opaque token for pagination.
+	NextCursor string `json:"nextCursor,omitempty"`
+}

--- a/pkg/mcpui/resource.go
+++ b/pkg/mcpui/resource.go
@@ -5,6 +5,7 @@
 package mcpui
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -116,13 +117,11 @@ func NewUIResourceContents(uri string, content UIContent) (*UIResourceContents, 
 
 	if wire.Blob != "" {
 		// Decode base64 blob back to bytes
-		var decoded []byte
-		if err := json.Unmarshal([]byte(`"`+wire.Blob+`"`), &decoded); err != nil {
-			// Try direct assignment if not base64
-			rc.Text = wire.Blob
-		} else {
-			rc.Blob = decoded
+		decoded, err := base64.StdEncoding.DecodeString(wire.Blob)
+		if err != nil {
+			return nil, errors.New("failed to decode base64 blob: " + err.Error())
 		}
+		rc.Blob = decoded
 	} else {
 		rc.Text = wire.Text
 	}
@@ -138,8 +137,8 @@ func (r *UIResourceContents) ToUIContent() (UIContent, error) {
 		Annotations: r.Annotations,
 	}
 	if r.Blob != nil {
-		// Encode blob to base64 string
-		wire.Blob = string(r.Blob) // Will be properly encoded by ContentFromWire
+		// Encode blob to base64 string for wire format
+		wire.Blob = base64.StdEncoding.EncodeToString(r.Blob)
 	}
 	return ContentFromWire(wire)
 }

--- a/pkg/mcpui/resource_test.go
+++ b/pkg/mcpui/resource_test.go
@@ -1,0 +1,401 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIResource_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource *UIResource
+		wantErr  string
+	}{
+		{
+			name: "valid resource",
+			resource: &UIResource{
+				URI:  "ui://dashboard/main",
+				Name: "Dashboard",
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing URI",
+			resource: &UIResource{
+				Name: "Dashboard",
+			},
+			wantErr: "missing URI",
+		},
+		{
+			name: "invalid URI scheme",
+			resource: &UIResource{
+				URI:  "http://example.com",
+				Name: "Dashboard",
+			},
+			wantErr: "must start with ui://",
+		},
+		{
+			name: "missing Name",
+			resource: &UIResource{
+				URI: "ui://dashboard/main",
+			},
+			wantErr: "missing Name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.resource.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUIResourceContents_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents *UIResourceContents
+		wantErr  bool
+		check    func(t *testing.T, data []byte)
+	}{
+		{
+			name: "text content",
+			contents: &UIResourceContents{
+				URI:      "ui://greeting/hello",
+				MIMEType: MIMETypeHTML,
+				Text:     "<div>Hello</div>",
+			},
+			check: func(t *testing.T, data []byte) {
+				var m map[string]any
+				require.NoError(t, json.Unmarshal(data, &m))
+				assert.Equal(t, "ui://greeting/hello", m["uri"])
+				assert.Equal(t, MIMETypeHTML, m["mimeType"])
+				assert.Equal(t, "<div>Hello</div>", m["text"])
+				_, hasBlob := m["blob"]
+				assert.False(t, hasBlob)
+			},
+		},
+		{
+			name: "blob content",
+			contents: &UIResourceContents{
+				URI:      "ui://image/logo",
+				MIMEType: "image/png",
+				Blob:     []byte{0x89, 0x50, 0x4E, 0x47},
+			},
+			check: func(t *testing.T, data []byte) {
+				var m map[string]any
+				require.NoError(t, json.Unmarshal(data, &m))
+				assert.Equal(t, "ui://image/logo", m["uri"])
+				assert.Equal(t, "image/png", m["mimeType"])
+				// blob should be base64 encoded
+				assert.NotNil(t, m["blob"])
+			},
+		},
+		{
+			name: "empty blob",
+			contents: &UIResourceContents{
+				URI:      "ui://empty/data",
+				MIMEType: "application/octet-stream",
+				Blob:     []byte{},
+			},
+			check: func(t *testing.T, data []byte) {
+				var m map[string]any
+				require.NoError(t, json.Unmarshal(data, &m))
+				// empty blob should still include the blob field
+				_, hasBlob := m["blob"]
+				assert.True(t, hasBlob, "blob field should be present for empty slice")
+			},
+		},
+		{
+			name: "missing URI",
+			contents: &UIResourceContents{
+				MIMEType: MIMETypeHTML,
+				Text:     "<div>No URI</div>",
+			},
+			wantErr: true,
+		},
+		{
+			name: "both text and blob",
+			contents: &UIResourceContents{
+				URI:      "ui://invalid/both",
+				MIMEType: MIMETypeHTML,
+				Text:     "text",
+				Blob:     []byte{1, 2, 3},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.contents.MarshalJSON()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, data)
+		})
+	}
+}
+
+func TestNewUIResourceContents(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		content UIContent
+		wantErr bool
+		check   func(t *testing.T, rc *UIResourceContents)
+	}{
+		{
+			name: "from HTMLContent",
+			uri:  "ui://greeting/hello",
+			content: &HTMLContent{
+				HTML: "<div>Hello World</div>",
+			},
+			check: func(t *testing.T, rc *UIResourceContents) {
+				assert.Equal(t, "ui://greeting/hello", rc.URI)
+				assert.Equal(t, MIMETypeHTML, rc.MIMEType)
+				assert.Equal(t, "<div>Hello World</div>", rc.Text)
+			},
+		},
+		{
+			name: "from URLContent",
+			uri:  "ui://external/dashboard",
+			content: &URLContent{
+				URL: "https://example.com/dashboard",
+			},
+			check: func(t *testing.T, rc *UIResourceContents) {
+				assert.Equal(t, "ui://external/dashboard", rc.URI)
+				assert.Equal(t, MIMETypeURLList, rc.MIMEType)
+				assert.Equal(t, "https://example.com/dashboard", rc.Text)
+			},
+		},
+		{
+			name: "from RemoteDOMContent",
+			uri:  "ui://component/widget",
+			content: &RemoteDOMContent{
+				Script:    "console.log('hello');",
+				Framework: FrameworkReact,
+			},
+			check: func(t *testing.T, rc *UIResourceContents) {
+				assert.Equal(t, "ui://component/widget", rc.URI)
+				assert.Contains(t, rc.MIMEType, MIMETypeRemoteDOM)
+				assert.Contains(t, rc.MIMEType, "react")
+				assert.Equal(t, "console.log('hello');", rc.Text)
+			},
+		},
+		{
+			name:    "empty URI",
+			uri:     "",
+			content: &HTMLContent{HTML: "test"},
+			wantErr: true,
+		},
+		{
+			name:    "nil content",
+			uri:     "ui://test/nil",
+			content: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, err := NewUIResourceContents(tt.uri, tt.content)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, rc)
+		})
+	}
+}
+
+func TestUIResourceContents_ToUIContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents *UIResourceContents
+		check    func(t *testing.T, c UIContent)
+	}{
+		{
+			name: "HTML content",
+			contents: &UIResourceContents{
+				URI:      "ui://test/html",
+				MIMEType: MIMETypeHTML,
+				Text:     "<p>Test</p>",
+			},
+			check: func(t *testing.T, c UIContent) {
+				html, ok := c.(*HTMLContent)
+				require.True(t, ok, "expected HTMLContent")
+				assert.Equal(t, "<p>Test</p>", html.HTML)
+			},
+		},
+		{
+			name: "URL content",
+			contents: &UIResourceContents{
+				URI:      "ui://test/url",
+				MIMEType: MIMETypeURLList,
+				Text:     "https://example.com",
+			},
+			check: func(t *testing.T, c UIContent) {
+				url, ok := c.(*URLContent)
+				require.True(t, ok, "expected URLContent")
+				assert.Equal(t, "https://example.com", url.URL)
+			},
+		},
+		{
+			name: "RemoteDOM content",
+			contents: &UIResourceContents{
+				URI:      "ui://test/dom",
+				MIMEType: MIMETypeRemoteDOM + "+javascript",
+				Text:     "document.write('hello');",
+			},
+			check: func(t *testing.T, c UIContent) {
+				dom, ok := c.(*RemoteDOMContent)
+				require.True(t, ok, "expected RemoteDOMContent")
+				assert.Equal(t, "document.write('hello');", dom.Script)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := tt.contents.ToUIContent()
+			require.NoError(t, err)
+			tt.check(t, content)
+		})
+	}
+}
+
+func TestUIResourceTemplate_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		template *UIResourceTemplate
+		wantErr  string
+	}{
+		{
+			name: "valid template",
+			template: &UIResourceTemplate{
+				URITemplate: "ui://dashboard/{id}",
+				Name:        "Dashboard",
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing URITemplate",
+			template: &UIResourceTemplate{
+				Name: "Dashboard",
+			},
+			wantErr: "missing URITemplate",
+		},
+		{
+			name: "invalid URI scheme",
+			template: &UIResourceTemplate{
+				URITemplate: "http://example.com/{id}",
+				Name:        "Dashboard",
+			},
+			wantErr: "must start with ui://",
+		},
+		{
+			name: "missing Name",
+			template: &UIResourceTemplate{
+				URITemplate: "ui://dashboard/{id}",
+			},
+			wantErr: "missing Name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.template.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUIResource_JSONSerialization(t *testing.T) {
+	resource := &UIResource{
+		URI:         "ui://dashboard/main",
+		Name:        "main-dashboard",
+		Title:       "Main Dashboard",
+		Description: "The primary dashboard view",
+		MIMEType:    MIMETypeHTML,
+		Annotations: &Annotations{
+			Audience: []string{"user"},
+		},
+	}
+
+	data, err := json.Marshal(resource)
+	require.NoError(t, err)
+
+	var decoded UIResource
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, resource.URI, decoded.URI)
+	assert.Equal(t, resource.Name, decoded.Name)
+	assert.Equal(t, resource.Title, decoded.Title)
+	assert.Equal(t, resource.Description, decoded.Description)
+	assert.Equal(t, resource.MIMEType, decoded.MIMEType)
+	assert.Equal(t, resource.Annotations.Audience, decoded.Annotations.Audience)
+}
+
+func TestListUIResourcesResult_JSONSerialization(t *testing.T) {
+	result := &ListUIResourcesResult{
+		Resources: []*UIResource{
+			{URI: "ui://test/one", Name: "one"},
+			{URI: "ui://test/two", Name: "two"},
+		},
+		NextCursor: "cursor123",
+	}
+
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var decoded ListUIResourcesResult
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Len(t, decoded.Resources, 2)
+	assert.Equal(t, "cursor123", decoded.NextCursor)
+}
+
+func TestReadUIResourceResult_JSONSerialization(t *testing.T) {
+	result := &ReadUIResourceResult{
+		Contents: []*UIResourceContents{
+			{
+				URI:      "ui://test/content",
+				MIMEType: MIMETypeHTML,
+				Text:     "<div>Content</div>",
+			},
+		},
+	}
+
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var decoded ReadUIResourceResult
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Len(t, decoded.Contents, 1)
+	assert.Equal(t, "ui://test/content", decoded.Contents[0].URI)
+}

--- a/pkg/mcpui/response.go
+++ b/pkg/mcpui/response.go
@@ -1,0 +1,133 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+// Response type constants for UI messages.
+const (
+	// ResponseTypeReceived acknowledges receipt of an action.
+	ResponseTypeReceived = "ui-message-received"
+	// ResponseTypeResponse sends the result of processing an action.
+	ResponseTypeResponse = "ui-message-response"
+)
+
+// UIResponse is sent from host to iframe in response to actions.
+type UIResponse struct {
+	// Type is the response type (ui-message-received or ui-message-response).
+	Type string `json:"type"`
+	// MessageID correlates this response to the originating action.
+	MessageID string `json:"messageId"`
+	// Payload contains the response data (only for ui-message-response).
+	Payload *ResponsePayload `json:"payload,omitempty"`
+}
+
+// ResponsePayload is the payload structure for ui-message-response.
+type ResponsePayload struct {
+	// Response contains the successful result data.
+	Response any `json:"response,omitempty"`
+	// Error contains error information if the action failed.
+	Error *ResponseError `json:"error,omitempty"`
+}
+
+// ResponseError contains error information for failed actions.
+type ResponseError struct {
+	// Message is a human-readable error description.
+	Message string `json:"message"`
+	// Code is an optional error code.
+	Code string `json:"code,omitempty"`
+	// Data contains additional error context.
+	Data any `json:"data,omitempty"`
+}
+
+// NewReceivedResponse creates an acknowledgment response.
+// This should be sent immediately when an action is received to confirm receipt.
+func NewReceivedResponse(messageID string) *UIResponse {
+	return &UIResponse{
+		Type:      ResponseTypeReceived,
+		MessageID: messageID,
+	}
+}
+
+// NewSuccessResponse creates a success response with the result data.
+// Use this when an action has been processed successfully.
+func NewSuccessResponse(messageID string, result any) *UIResponse {
+	return &UIResponse{
+		Type:      ResponseTypeResponse,
+		MessageID: messageID,
+		Payload: &ResponsePayload{
+			Response: result,
+		},
+	}
+}
+
+// NewErrorResponse creates an error response.
+// Use this when an action fails to process.
+func NewErrorResponse(messageID string, err error) *UIResponse {
+	return &UIResponse{
+		Type:      ResponseTypeResponse,
+		MessageID: messageID,
+		Payload: &ResponsePayload{
+			Error: &ResponseError{
+				Message: err.Error(),
+			},
+		},
+	}
+}
+
+// NewErrorResponseWithCode creates an error response with an error code.
+func NewErrorResponseWithCode(messageID string, code string, message string) *UIResponse {
+	return &UIResponse{
+		Type:      ResponseTypeResponse,
+		MessageID: messageID,
+		Payload: &ResponsePayload{
+			Error: &ResponseError{
+				Code:    code,
+				Message: message,
+			},
+		},
+	}
+}
+
+// NewErrorResponseWithData creates an error response with additional context data.
+func NewErrorResponseWithData(messageID string, err error, data any) *UIResponse {
+	return &UIResponse{
+		Type:      ResponseTypeResponse,
+		MessageID: messageID,
+		Payload: &ResponsePayload{
+			Error: &ResponseError{
+				Message: err.Error(),
+				Data:    data,
+			},
+		},
+	}
+}
+
+// IsSuccess returns true if this response indicates success.
+func (r *UIResponse) IsSuccess() bool {
+	if r.Type == ResponseTypeReceived {
+		return true
+	}
+	return r.Payload != nil && r.Payload.Error == nil
+}
+
+// IsError returns true if this response indicates an error.
+func (r *UIResponse) IsError() bool {
+	return r.Type == ResponseTypeResponse && r.Payload != nil && r.Payload.Error != nil
+}
+
+// GetError returns the error if present, nil otherwise.
+func (r *UIResponse) GetError() *ResponseError {
+	if r.Payload == nil {
+		return nil
+	}
+	return r.Payload.Error
+}
+
+// GetResponse returns the response data if present, nil otherwise.
+func (r *UIResponse) GetResponse() any {
+	if r.Payload == nil {
+		return nil
+	}
+	return r.Payload.Response
+}

--- a/pkg/mcpui/response_test.go
+++ b/pkg/mcpui/response_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 The MCP-UI Go SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcpui
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReceivedResponse(t *testing.T) {
+	resp := NewReceivedResponse("msg-123")
+
+	assert.Equal(t, ResponseTypeReceived, resp.Type)
+	assert.Equal(t, "msg-123", resp.MessageID)
+	assert.Nil(t, resp.Payload)
+	assert.True(t, resp.IsSuccess())
+	assert.False(t, resp.IsError())
+}
+
+func TestNewSuccessResponse(t *testing.T) {
+	result := map[string]any{
+		"status": "ok",
+		"data":   []string{"a", "b", "c"},
+	}
+	resp := NewSuccessResponse("msg-456", result)
+
+	assert.Equal(t, ResponseTypeResponse, resp.Type)
+	assert.Equal(t, "msg-456", resp.MessageID)
+	assert.NotNil(t, resp.Payload)
+	assert.Nil(t, resp.Payload.Error)
+	assert.Equal(t, result, resp.Payload.Response)
+	assert.True(t, resp.IsSuccess())
+	assert.False(t, resp.IsError())
+	assert.Equal(t, result, resp.GetResponse())
+	assert.Nil(t, resp.GetError())
+}
+
+func TestNewErrorResponse(t *testing.T) {
+	err := errors.New("something went wrong")
+	resp := NewErrorResponse("msg-789", err)
+
+	assert.Equal(t, ResponseTypeResponse, resp.Type)
+	assert.Equal(t, "msg-789", resp.MessageID)
+	assert.NotNil(t, resp.Payload)
+	assert.NotNil(t, resp.Payload.Error)
+	assert.Equal(t, "something went wrong", resp.Payload.Error.Message)
+	assert.Empty(t, resp.Payload.Error.Code)
+	assert.False(t, resp.IsSuccess())
+	assert.True(t, resp.IsError())
+	assert.Nil(t, resp.GetResponse())
+	assert.NotNil(t, resp.GetError())
+}
+
+func TestNewErrorResponseWithCode(t *testing.T) {
+	resp := NewErrorResponseWithCode("msg-abc", "INVALID_PARAMS", "Missing required parameter")
+
+	assert.Equal(t, ResponseTypeResponse, resp.Type)
+	assert.Equal(t, "msg-abc", resp.MessageID)
+	assert.NotNil(t, resp.Payload.Error)
+	assert.Equal(t, "INVALID_PARAMS", resp.Payload.Error.Code)
+	assert.Equal(t, "Missing required parameter", resp.Payload.Error.Message)
+}
+
+func TestNewErrorResponseWithData(t *testing.T) {
+	err := errors.New("validation failed")
+	data := map[string]any{
+		"field":   "email",
+		"details": "invalid format",
+	}
+	resp := NewErrorResponseWithData("msg-def", err, data)
+
+	assert.Equal(t, ResponseTypeResponse, resp.Type)
+	assert.Equal(t, "msg-def", resp.MessageID)
+	assert.NotNil(t, resp.Payload.Error)
+	assert.Equal(t, "validation failed", resp.Payload.Error.Message)
+	assert.Equal(t, data, resp.Payload.Error.Data)
+}
+
+func TestUIResponse_JSONSerialization(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *UIResponse
+	}{
+		{
+			name: "received response",
+			resp: NewReceivedResponse("test-id"),
+		},
+		{
+			name: "success response",
+			resp: NewSuccessResponse("test-id", map[string]string{"key": "value"}),
+		},
+		{
+			name: "error response",
+			resp: NewErrorResponse("test-id", errors.New("test error")),
+		},
+		{
+			name: "error with code",
+			resp: NewErrorResponseWithCode("test-id", "ERR_001", "test error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.resp)
+			require.NoError(t, err)
+
+			var decoded UIResponse
+			err = json.Unmarshal(data, &decoded)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.resp.Type, decoded.Type)
+			assert.Equal(t, tt.resp.MessageID, decoded.MessageID)
+		})
+	}
+}
+
+func TestUIResponse_JSONFormat(t *testing.T) {
+	t.Run("received format", func(t *testing.T) {
+		resp := NewReceivedResponse("msg-123")
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]any
+		err = json.Unmarshal(data, &m)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ui-message-received", m["type"])
+		assert.Equal(t, "msg-123", m["messageId"])
+		_, hasPayload := m["payload"]
+		assert.False(t, hasPayload, "payload should be omitted for received")
+	})
+
+	t.Run("success format", func(t *testing.T) {
+		resp := NewSuccessResponse("msg-456", "result data")
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]any
+		err = json.Unmarshal(data, &m)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ui-message-response", m["type"])
+		assert.Equal(t, "msg-456", m["messageId"])
+		payload := m["payload"].(map[string]any)
+		assert.Equal(t, "result data", payload["response"])
+		_, hasError := payload["error"]
+		assert.False(t, hasError)
+	})
+
+	t.Run("error format", func(t *testing.T) {
+		resp := NewErrorResponse("msg-789", errors.New("test error"))
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]any
+		err = json.Unmarshal(data, &m)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ui-message-response", m["type"])
+		payload := m["payload"].(map[string]any)
+		errObj := payload["error"].(map[string]any)
+		assert.Equal(t, "test error", errObj["message"])
+	})
+}
+
+func TestResponseTypeConstants(t *testing.T) {
+	// Verify constants match protocol specification
+	assert.Equal(t, "ui-message-received", ResponseTypeReceived)
+	assert.Equal(t, "ui-message-response", ResponseTypeResponse)
+}
+
+func TestUIResponse_HelperMethods(t *testing.T) {
+	t.Run("received response helpers", func(t *testing.T) {
+		resp := NewReceivedResponse("id")
+		assert.True(t, resp.IsSuccess())
+		assert.False(t, resp.IsError())
+		assert.Nil(t, resp.GetError())
+		assert.Nil(t, resp.GetResponse())
+	})
+
+	t.Run("success response helpers", func(t *testing.T) {
+		resp := NewSuccessResponse("id", "data")
+		assert.True(t, resp.IsSuccess())
+		assert.False(t, resp.IsError())
+		assert.Nil(t, resp.GetError())
+		assert.Equal(t, "data", resp.GetResponse())
+	})
+
+	t.Run("error response helpers", func(t *testing.T) {
+		resp := NewErrorResponse("id", errors.New("err"))
+		assert.False(t, resp.IsSuccess())
+		assert.True(t, resp.IsError())
+		assert.NotNil(t, resp.GetError())
+		assert.Nil(t, resp.GetResponse())
+	})
+
+	t.Run("nil payload response", func(t *testing.T) {
+		resp := &UIResponse{Type: ResponseTypeResponse, MessageID: "id"}
+		assert.False(t, resp.IsSuccess())
+		assert.False(t, resp.IsError())
+		assert.Nil(t, resp.GetError())
+		assert.Nil(t, resp.GetResponse())
+	})
+}


### PR DESCRIPTION
## Summary

Implement a Go SDK for the MCP-UI protocol (SEP-1865 "MCP Apps Extension"). This is the **first Go implementation** of MCP-UI - previously only TypeScript, Python, and Ruby SDKs existed.

### What is MCP-UI?

MCP-UI is an open protocol (standardized as SEP-1865 by Anthropic + OpenAI) enabling MCP servers to return interactive UI resources that clients render in sandboxed iframes. Adopted by Shopify, Postman, Hugging Face, ElevenLabs, and others.

## Package Structure

| File | Description |
|------|-------------|
| `content.go` | UIContent interface, HTMLContent, URLContent, RemoteDOMContent, BlobContent |
| `resource.go` | UIResource, UIResourceContents, UIResourceTemplate |
| `action.go` | UIAction with all payload types (tool, intent, prompt, notify, link, ui-size-change) |
| `response.go` | UIResponse with builders (NewReceivedResponse, NewSuccessResponse, NewErrorResponse) |
| `handler.go` | UIActionHandler, Router for dispatching actions, typed handler wrappers |
| `doc.go` | Package documentation with usage examples |

## Key Features

- Follows official MCP Go SDK idioms (Content interface, wire types, handler patterns)
- Full MCP-UI protocol support including all action and response types
- Router for dispatching actions by type or resource URI
- Typed handler wrappers for each action type
- **84.7% test coverage** with comprehensive unit tests
- 13 runnable examples in example_test.go

## Design Decisions

- **SDK Location**: Built as `pkg/mcpui/` for later extraction as `github.com/ironystock/mcpui-go`
- **API Design**: Mirrors official go-sdk patterns (Content interface, MarshalJSON, handler types)
- **Full Protocol**: All content types, action types, and response types implemented

## Test Plan

- [x] All unit tests pass (`go test ./pkg/mcpui/...`)
- [x] go vet passes
- [x] gofmt check passes
- [x] Build succeeds
- [x] 84.7% test coverage

## Future Work

- **FB-13**: Integrate MCP-UI into agentic-obs tools
- **FB-15** (new): Extract to standalone `github.com/ironystock/mcpui-go` repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)