### PR TITLE
FB-13: MCP-UI Integration

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -550,6 +550,7 @@ CREATE TABLE state (
 - [ ] Additional resource types (sources, filters, transitions, audio inputs)
 - [ ] Resource subscriptions (explicit client opt-in)
 - [ ] Action logging hooks in MCP tool handlers
+- [ ] Scene-specific audio mixer UI (show only audio sources in current scene, not all inputs)
 
 **Success Criteria:**
 - TUI offers command-line management

--- a/config/config.go
+++ b/config/config.go
@@ -45,9 +45,10 @@ type ToolGroupConfig struct {
 
 // WebServerConfig controls HTTP server settings
 type WebServerConfig struct {
-	Enabled bool   // Whether HTTP server is enabled
-	Host    string // HTTP server host
-	Port    int    // HTTP server port
+	Enabled           bool   // Whether HTTP server is enabled
+	Host              string // HTTP server host
+	Port              int    // HTTP server port
+	ThumbnailCacheSec int    // Cache duration for thumbnails in seconds (0 to disable)
 }
 
 // DefaultConfig returns a configuration with sensible defaults
@@ -73,9 +74,10 @@ func DefaultConfig() *Config {
 			Design:  true,
 		},
 		WebServer: WebServerConfig{
-			Enabled: true,
-			Host:    "localhost",
-			Port:    8765,
+			Enabled:           true,
+			Host:              "localhost",
+			Port:              8765,
+			ThumbnailCacheSec: 5, // 5 seconds default, 0 for development
 		},
 	}
 }
@@ -248,9 +250,10 @@ func LoadFromStorage(ctx context.Context, dbPath string) (*Config, error) {
 		log.Printf("Warning: failed to load webserver config: %v", err)
 	} else {
 		cfg.WebServer = WebServerConfig{
-			Enabled: webCfg.Enabled,
-			Host:    webCfg.Host,
-			Port:    webCfg.Port,
+			Enabled:           webCfg.Enabled,
+			Host:              webCfg.Host,
+			Port:              webCfg.Port,
+			ThumbnailCacheSec: webCfg.ThumbnailCacheSec,
 		}
 	}
 
@@ -299,9 +302,10 @@ func SaveToStorage(ctx context.Context, cfg *Config) error {
 
 	// Save webserver configuration
 	webCfg := storage.WebServerConfig{
-		Enabled: cfg.WebServer.Enabled,
-		Host:    cfg.WebServer.Host,
-		Port:    cfg.WebServer.Port,
+		Enabled:           cfg.WebServer.Enabled,
+		Host:              cfg.WebServer.Host,
+		Port:              cfg.WebServer.Port,
+		ThumbnailCacheSec: cfg.WebServer.ThumbnailCacheSec,
 	}
 	if err := db.SaveWebServerConfig(ctx, webCfg); err != nil {
 		return fmt.Errorf("failed to save webserver config: %w", err)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -134,10 +134,16 @@ func (s *Server) setupRoutes() *http.ServeMux {
 		baseURL := fmt.Sprintf("http://%s", s.addr)
 		s.uiHandlers = NewUIHandlers(s.statusProvider, baseURL)
 
+		// Set action executor if provider implements it
+		if executor, ok := s.statusProvider.(ActionExecutor); ok {
+			s.uiHandlers.SetActionExecutor(executor)
+		}
+
 		mux.HandleFunc("/ui/status", s.uiHandlers.HandleUIStatus)
 		mux.HandleFunc("/ui/scenes", s.uiHandlers.HandleUIScenes)
 		mux.HandleFunc("/ui/audio", s.uiHandlers.HandleUIAudio)
 		mux.HandleFunc("/ui/screenshots", s.uiHandlers.HandleUIScreenshots)
+		mux.HandleFunc("/ui/scene-thumbnail/", s.uiHandlers.HandleSceneThumbnail)
 		mux.HandleFunc("/ui/action", s.uiHandlers.HandleUIAction)
 	}
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -29,6 +29,8 @@ type Config struct {
 	Host string
 	// Port to listen on (default: 8765)
 	Port int
+	// ThumbnailCacheSec is the Cache-Control max-age for thumbnails (0 to disable)
+	ThumbnailCacheSec int
 }
 
 // isValidSourceName validates that a source name is safe to use.
@@ -66,8 +68,9 @@ func isValidSourceName(name string) bool {
 // DefaultConfig returns the default HTTP server configuration.
 func DefaultConfig() Config {
 	return Config{
-		Host: "localhost",
-		Port: 8765,
+		Host:              "localhost",
+		Port:              8765,
+		ThumbnailCacheSec: 5, // 5 seconds default, 0 for development
 	}
 }
 
@@ -141,7 +144,7 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	// MCP-UI endpoints (only if status provider is configured)
 	if s.statusProvider != nil {
 		baseURL := fmt.Sprintf("http://%s", s.addr)
-		s.uiHandlers = NewUIHandlers(s.statusProvider, baseURL)
+		s.uiHandlers = NewUIHandlers(s.statusProvider, baseURL, s.cfg.ThumbnailCacheSec)
 
 		// Set action executor if provider implements it
 		if executor, ok := s.statusProvider.(ActionExecutor); ok {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -110,8 +110,17 @@ func NewServer(db *storage.DB, cfg Config) *Server {
 
 // SetStatusProvider configures the status provider for MCP-UI endpoints.
 // This must be called before Start() to enable UI routes.
-func (s *Server) SetStatusProvider(provider StatusProvider) {
+// Returns an error if the server is already running.
+func (s *Server) SetStatusProvider(provider StatusProvider) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		return fmt.Errorf("cannot set status provider: server already running")
+	}
+
 	s.statusProvider = provider
+	return nil
 }
 
 // setupRoutes configures all HTTP routes.

--- a/internal/http/templates/audio_mixer.html
+++ b/internal/http/templates/audio_mixer.html
@@ -217,6 +217,33 @@
     margin-bottom: 12px;
     opacity: 0.5;
 }
+
+.connection-status {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--error);
+    color: white;
+    padding: 12px 20px;
+    border-radius: 8px;
+    display: none;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.85rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    z-index: 1000;
+}
+
+.connection-status.visible {
+    display: flex;
+}
+
+.connection-status svg {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
@@ -239,7 +266,7 @@
                     <div class="channel-controls">
                         <span class="volume-display">{{printf "%.1f" .VolumeDB}} dB</span>
                         <button class="mute-toggle {{if .IsMuted}}muted{{end}}"
-                                onclick="toggleMute('{{.Name}}')"
+                                onclick="toggleMute(this)"
                                 title="{{if .IsMuted}}Unmute{{else}}Mute{{end}} (M)">
                             {{if .IsMuted}}
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -265,7 +292,7 @@
                        value="{{printf "%.0f" .VolumePercent}}"
                        data-input="{{.Name}}"
                        oninput="updateSlider(this, false)"
-                       onchange="updateSlider(this, true); setVolume('{{.Name}}', this.value)">
+                       onchange="updateSlider(this, true); setVolume(this.dataset.input, this.value)">
                 <div class="db-markers">
                     <span>-&#8734;</span>
                     <span>-18</span>
@@ -294,6 +321,12 @@
     </div>
 
     <div class="refresh-indicator" id="refreshIndicator">Updating...</div>
+    <div class="connection-status" id="connectionStatus">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M1 1l22 22M16.72 11.06A10.94 10.94 0 0 1 19 12.55M5 12.55a10.94 10.94 0 0 1 5.17-2.39M10.71 5.05A16 16 0 0 1 22.58 9M1.42 9a15.91 15.91 0 0 1 4.7-2.88M8.53 16.11a6 6 0 0 1 6.95 0M12 20h.01"/>
+        </svg>
+        <span>Connection lost - retrying...</span>
+    </div>
 
     <script>
         let focusedIndex = 0;
@@ -304,30 +337,38 @@
             return Math.round(db * 2) / 2;
         }
 
-        // Logarithmic audio fader curve
-        // Attempt to match perceptual loudness: slider position = perceived volume
-        // Uses: slider = 10^(dB/30) * 100, giving roughly:
-        //   0dB=100%, -3dB~79%, -10dB~46%, -20dB~22%, -30dB=10%, -60dB~1%
+        // Logarithmic audio fader curve for perceptual loudness control
+        //
+        // The constant 30 in the formula dB = 30 * log10(slider/100) is derived from:
+        // - Human perception of loudness follows approximately a power law (Stevens' law)
+        // - A 10dB change is perceived as roughly "twice as loud" or "half as loud"
+        // - Using 30 creates a curve where slider position ≈ perceived loudness:
+        //   100% = 0dB (unity), 50% ≈ -10dB (half perceived volume),
+        //   25% ≈ -18dB, 10% = -30dB, 1% ≈ -60dB (near silence)
+        //
+        // This matches professional audio mixing consoles which use log tapers.
         function sliderToDb(value) {
             if (value <= 0) return -100; // Mute
             if (value >= 100) return 0;
-            // dB = 30 * log10(value/100)
             const db = 30 * Math.log10(value / 100);
             return snapToHalfDb(db);
         }
 
-        // Convert dB to slider value (0-100) using logarithmic curve
+        // Convert dB to slider value (0-100) - inverse of sliderToDb
         function dbToSlider(db) {
             if (db <= -60) return 0;
             if (db >= 0) return 100;
-            // slider = 10^(dB/30) * 100
             return Math.pow(10, db / 30) * 100;
         }
 
         function updateSlider(slider, snap = false) {
-            const channel = slider.closest('.audio-channel');
+            const channel = slider?.closest('.audio-channel');
+            if (!channel) return; // Guard against missing parent
+
             const fill = channel.querySelector('.slider-fill');
             const display = channel.querySelector('.volume-display');
+            if (!fill || !display) return; // Guard against missing DOM elements
+
             let value = parseFloat(slider.value);
 
             // Snap to 0.5dB increments
@@ -342,8 +383,16 @@
             display.textContent = db + ' dB';
         }
 
-        function toggleMute(inputName) {
+        function toggleMute(btn) {
+            const channel = btn.closest('.audio-channel');
+            const inputName = channel?.dataset.input;
+            if (!channel || !inputName) return;
+
             showRefreshIndicator();
+
+            // Optimistic UI update - toggle mute state immediately
+            const wasMuted = channel.classList.contains('muted');
+
             fetch('{{.BaseURL}}/ui/action', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -355,14 +404,32 @@
             })
             .then(response => response.json())
             .then(data => {
+                hideRefreshIndicator();
                 if (data.payload && data.payload.error) {
                     alert('Error: ' + data.payload.error.message);
-                    hideRefreshIndicator();
                 } else {
-                    refreshAudioState();
+                    // Update the channel's mute state in the DOM
+                    const nowMuted = !wasMuted;
+                    channel.classList.toggle('muted', nowMuted);
+                    btn.classList.toggle('muted', nowMuted);
+                    btn.title = nowMuted ? 'Unmute (M)' : 'Mute (M)';
+                    // Update the icon
+                    btn.innerHTML = nowMuted
+                        ? `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                             <path d="M11 5L6 9H2v6h4l5 4V5z"/>
+                             <line x1="23" y1="9" x2="17" y2="15"/>
+                             <line x1="17" y1="9" x2="23" y2="15"/>
+                           </svg>`
+                        : `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                             <path d="M11 5L6 9H2v6h4l5 4V5z"/>
+                             <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"/>
+                           </svg>`;
                 }
             })
-            .catch(() => hideRefreshIndicator());
+            .catch(err => {
+                hideRefreshIndicator();
+                console.error('Mute toggle failed:', err);
+            });
         }
 
         function setVolume(inputName, value) {
@@ -384,10 +451,6 @@
 
         function hideRefreshIndicator() {
             document.getElementById('refreshIndicator').classList.remove('visible');
-        }
-
-        function refreshAudioState() {
-            location.reload();
         }
 
         function setFocus(index) {
@@ -443,7 +506,8 @@
                 case 'm':
                 case 'M':
                     e.preventDefault();
-                    if (inputName) toggleMute(inputName);
+                    const muteBtn = focusedChannel?.querySelector('.mute-toggle');
+                    if (muteBtn) toggleMute(muteBtn);
                     break;
                 case '0':
                     e.preventDefault();
@@ -469,11 +533,39 @@
             });
         });
 
-        // Auto-refresh audio state every 3 seconds
-        setInterval(() => {
+        // Auto-refresh with error handling and exponential backoff
+        let refreshFailures = 0;
+        const baseInterval = 3000;
+        const maxInterval = 30000;
+        let refreshTimer = null;
+
+        function showConnectionError() {
+            document.getElementById('connectionStatus').classList.add('visible');
+        }
+
+        function hideConnectionError() {
+            document.getElementById('connectionStatus').classList.remove('visible');
+        }
+
+        function scheduleRefresh() {
+            // Exponential backoff: 3s, 6s, 12s, 24s, max 30s
+            const interval = Math.min(baseInterval * Math.pow(2, refreshFailures), maxInterval);
+            refreshTimer = setTimeout(refreshAudioStateAuto, interval);
+        }
+
+        function refreshAudioStateAuto() {
             fetch('{{.BaseURL}}/ui/audio')
-                .then(response => response.text())
+                .then(response => {
+                    if (!response.ok) throw new Error('HTTP ' + response.status);
+                    return response.text();
+                })
                 .then(html => {
+                    // Reset failures on success
+                    if (refreshFailures > 0) {
+                        refreshFailures = 0;
+                        hideConnectionError();
+                    }
+
                     // Only refresh if no slider is being dragged
                     if (!document.querySelector('.volume-slider:active')) {
                         const parser = new DOMParser();
@@ -500,8 +592,21 @@
                             }
                         });
                     }
+                    scheduleRefresh();
+                })
+                .catch(err => {
+                    console.warn('Audio refresh failed:', err.message);
+                    refreshFailures++;
+                    // Show error after 2 consecutive failures
+                    if (refreshFailures >= 2) {
+                        showConnectionError();
+                    }
+                    scheduleRefresh();
                 });
-        }, 3000);
+        }
+
+        // Start auto-refresh
+        scheduleRefresh();
 
         // Initial focus
         if (channels.length > 0) setFocus(0);

--- a/internal/http/templates/audio_mixer.html
+++ b/internal/http/templates/audio_mixer.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Audio Mixer</title>
+    <style>
+{{.SharedCSS}}
+
+.audio-channel {
+    background: var(--bg-card);
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 12px;
+    transition: all 0.2s;
+    border: 2px solid transparent;
+}
+
+.audio-channel:hover {
+    border-color: var(--border);
+}
+
+.audio-channel.focused {
+    border-color: var(--accent);
+}
+
+.audio-channel.muted {
+    opacity: 0.6;
+}
+
+.channel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.channel-info {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.channel-name {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.channel-type {
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    text-transform: uppercase;
+}
+
+.channel-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.volume-display {
+    font-family: monospace;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    min-width: 70px;
+    text-align: right;
+}
+
+.mute-toggle {
+    width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+.mute-toggle:hover {
+    background: var(--border);
+}
+
+.mute-toggle.muted {
+    background: var(--error);
+    color: white;
+}
+
+.mute-toggle svg {
+    width: 20px;
+    height: 20px;
+}
+
+.slider-track {
+    position: relative;
+    height: 8px;
+    background: var(--bg-secondary);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.slider-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    background: linear-gradient(90deg, var(--success) 0%, var(--warning) 70%, var(--error) 100%);
+    border-radius: 4px;
+    transition: width 0.1s;
+}
+
+.audio-channel.muted .slider-fill {
+    background: var(--text-secondary);
+}
+
+.volume-slider {
+    width: 100%;
+    height: 8px;
+    -webkit-appearance: none;
+    background: transparent;
+    position: relative;
+    z-index: 1;
+    margin-top: -8px;
+}
+
+.volume-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--text-primary);
+    cursor: pointer;
+    border: 2px solid var(--bg-card);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    transition: transform 0.1s;
+}
+
+.volume-slider::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+}
+
+.volume-slider::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--text-primary);
+    cursor: pointer;
+    border: 2px solid var(--bg-card);
+}
+
+.db-markers {
+    position: relative;
+    height: 1.2em;
+    margin-top: 4px;
+    font-size: 0.65rem;
+    color: var(--text-secondary);
+}
+
+.db-markers span {
+    position: absolute;
+    transform: translateX(-50%);
+}
+
+/* Logarithmic scale positions: 10^(dB/30) * 100 */
+.db-markers span:nth-child(1) { left: 0%; transform: translateX(0); }      /* -inf at 0% */
+.db-markers span:nth-child(2) { left: 25.1%; }   /* -18dB at 25.1% */
+.db-markers span:nth-child(3) { left: 50.1%; }   /* -9dB at 50.1% */
+.db-markers span:nth-child(4) { left: 79.4%; }   /* -3dB at 79.4% */
+.db-markers span:nth-child(5) { left: 100%; transform: translateX(-100%); } /* 0dB at 100% */
+
+.keyboard-hint {
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    margin-top: 20px;
+}
+
+.keyboard-hint kbd {
+    background: var(--bg-card);
+    padding: 2px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+}
+
+.refresh-indicator {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.refresh-indicator.visible {
+    opacity: 1;
+}
+
+.no-inputs {
+    text-align: center;
+    padding: 40px;
+    color: var(--text-secondary);
+}
+
+.no-inputs svg {
+    width: 48px;
+    height: 48px;
+    margin-bottom: 12px;
+    opacity: 0.5;
+}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Audio <span class="accent">Mixer</span></h1>
+
+        <div class="card">
+            <h2>Audio Inputs ({{len .Inputs}})</h2>
+            {{if .Inputs}}
+            {{range $i, $input := .Inputs}}
+            <div class="audio-channel {{if .IsMuted}}muted{{end}}"
+                 data-input="{{.Name}}"
+                 data-index="{{$i}}"
+                 tabindex="0">
+                <div class="channel-header">
+                    <div class="channel-info">
+                        <span class="channel-name">{{.Name}}</span>
+                        <span class="channel-type">{{.InputKind}}</span>
+                    </div>
+                    <div class="channel-controls">
+                        <span class="volume-display">{{printf "%.1f" .VolumeDB}} dB</span>
+                        <button class="mute-toggle {{if .IsMuted}}muted{{end}}"
+                                onclick="toggleMute('{{.Name}}')"
+                                title="{{if .IsMuted}}Unmute{{else}}Mute{{end}} (M)">
+                            {{if .IsMuted}}
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M11 5L6 9H2v6h4l5 4V5z"/>
+                                <line x1="23" y1="9" x2="17" y2="15"/>
+                                <line x1="17" y1="9" x2="23" y2="15"/>
+                            </svg>
+                            {{else}}
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M11 5L6 9H2v6h4l5 4V5z"/>
+                                <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"/>
+                            </svg>
+                            {{end}}
+                        </button>
+                    </div>
+                </div>
+                <div class="slider-track">
+                    <div class="slider-fill" style="width: {{printf "%.0f" .VolumePercent}}%"></div>
+                </div>
+                <input type="range"
+                       class="volume-slider"
+                       min="0" max="100"
+                       value="{{printf "%.0f" .VolumePercent}}"
+                       data-input="{{.Name}}"
+                       oninput="updateSlider(this, false)"
+                       onchange="updateSlider(this, true); setVolume('{{.Name}}', this.value)">
+                <div class="db-markers">
+                    <span>-&#8734;</span>
+                    <span>-18</span>
+                    <span>-9</span>
+                    <span>-3</span>
+                    <span>0 dB</span>
+                </div>
+            </div>
+            {{end}}
+            {{else}}
+            <div class="no-inputs">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M11 5L6 9H2v6h4l5 4V5z"/>
+                    <line x1="23" y1="9" x2="17" y2="15"/>
+                    <line x1="17" y1="9" x2="23" y2="15"/>
+                </svg>
+                <p>No audio inputs available</p>
+                <p style="font-size: 0.8rem; margin-top: 8px;">Connect to OBS to see audio sources</p>
+            </div>
+            {{end}}
+        </div>
+
+        <div class="keyboard-hint">
+            <kbd>&#8593;</kbd><kbd>&#8595;</kbd> Navigate | <kbd>&#8592;</kbd><kbd>&#8594;</kbd> Adjust Volume | <kbd>M</kbd> Mute/Unmute | <kbd>0</kbd> Reset
+        </div>
+    </div>
+
+    <div class="refresh-indicator" id="refreshIndicator">Updating...</div>
+
+    <script>
+        let focusedIndex = 0;
+        const channels = document.querySelectorAll('.audio-channel');
+
+        // Snap dB value to 0.5 increments
+        function snapToHalfDb(db) {
+            return Math.round(db * 2) / 2;
+        }
+
+        // Logarithmic audio fader curve
+        // Attempt to match perceptual loudness: slider position = perceived volume
+        // Uses: slider = 10^(dB/30) * 100, giving roughly:
+        //   0dB=100%, -3dB~79%, -10dB~46%, -20dB~22%, -30dB=10%, -60dB~1%
+        function sliderToDb(value) {
+            if (value <= 0) return -100; // Mute
+            if (value >= 100) return 0;
+            // dB = 30 * log10(value/100)
+            const db = 30 * Math.log10(value / 100);
+            return snapToHalfDb(db);
+        }
+
+        // Convert dB to slider value (0-100) using logarithmic curve
+        function dbToSlider(db) {
+            if (db <= -60) return 0;
+            if (db >= 0) return 100;
+            // slider = 10^(dB/30) * 100
+            return Math.pow(10, db / 30) * 100;
+        }
+
+        function updateSlider(slider, snap = false) {
+            const channel = slider.closest('.audio-channel');
+            const fill = channel.querySelector('.slider-fill');
+            const display = channel.querySelector('.volume-display');
+            let value = parseFloat(slider.value);
+
+            // Snap to 0.5dB increments
+            if (snap && value > 0) {
+                const db = sliderToDb(value);
+                value = dbToSlider(db);
+                slider.value = value;
+            }
+
+            fill.style.width = value + '%';
+            const db = value === 0 ? '-\u221E' : sliderToDb(value).toFixed(1);
+            display.textContent = db + ' dB';
+        }
+
+        function toggleMute(inputName) {
+            showRefreshIndicator();
+            fetch('{{.BaseURL}}/ui/action', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    type: 'tool',
+                    messageId: 'mute-' + Date.now(),
+                    payload: { toolName: 'toggle_input_mute', params: { input_name: inputName } }
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.payload && data.payload.error) {
+                    alert('Error: ' + data.payload.error.message);
+                    hideRefreshIndicator();
+                } else {
+                    refreshAudioState();
+                }
+            })
+            .catch(() => hideRefreshIndicator());
+        }
+
+        function setVolume(inputName, value) {
+            const db = sliderToDb(value);
+            fetch('{{.BaseURL}}/ui/action', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    type: 'tool',
+                    messageId: 'vol-' + Date.now(),
+                    payload: { toolName: 'set_input_volume', params: { input_name: inputName, volume_db: db } }
+                })
+            });
+        }
+
+        function showRefreshIndicator() {
+            document.getElementById('refreshIndicator').classList.add('visible');
+        }
+
+        function hideRefreshIndicator() {
+            document.getElementById('refreshIndicator').classList.remove('visible');
+        }
+
+        function refreshAudioState() {
+            location.reload();
+        }
+
+        function setFocus(index) {
+            if (index < 0) index = channels.length - 1;
+            if (index >= channels.length) index = 0;
+            focusedIndex = index;
+
+            channels.forEach((ch, i) => {
+                ch.classList.toggle('focused', i === index);
+            });
+            channels[index].focus();
+        }
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            if (channels.length === 0) return;
+
+            const focusedChannel = channels[focusedIndex];
+            const slider = focusedChannel?.querySelector('.volume-slider');
+            const inputName = focusedChannel?.dataset.input;
+
+            switch (e.key) {
+                case 'ArrowUp':
+                    e.preventDefault();
+                    setFocus(focusedIndex - 1);
+                    break;
+                case 'ArrowDown':
+                    e.preventDefault();
+                    setFocus(focusedIndex + 1);
+                    break;
+                case 'ArrowLeft':
+                    e.preventDefault();
+                    if (slider) {
+                        // Decrease by 0.5dB
+                        const currentDb = sliderToDb(slider.value);
+                        const newDb = Math.max(-60, currentDb - 0.5);
+                        slider.value = dbToSlider(newDb);
+                        updateSlider(slider, true);
+                        setVolume(inputName, slider.value);
+                    }
+                    break;
+                case 'ArrowRight':
+                    e.preventDefault();
+                    if (slider) {
+                        // Increase by 0.5dB
+                        const currentDb = sliderToDb(slider.value);
+                        const newDb = Math.min(0, currentDb + 0.5);
+                        slider.value = dbToSlider(newDb);
+                        updateSlider(slider, true);
+                        setVolume(inputName, slider.value);
+                    }
+                    break;
+                case 'm':
+                case 'M':
+                    e.preventDefault();
+                    if (inputName) toggleMute(inputName);
+                    break;
+                case '0':
+                    e.preventDefault();
+                    if (slider) {
+                        slider.value = 100; // 0 dB (unity gain)
+                        updateSlider(slider, true);
+                        setVolume(inputName, slider.value);
+                    }
+                    break;
+            }
+        });
+
+        // Click to focus channel
+        channels.forEach((channel, index) => {
+            channel.addEventListener('click', (e) => {
+                if (!e.target.closest('.mute-toggle')) {
+                    setFocus(index);
+                }
+            });
+            channel.addEventListener('focus', () => {
+                focusedIndex = index;
+                channels.forEach((ch, i) => ch.classList.toggle('focused', i === index));
+            });
+        });
+
+        // Auto-refresh audio state every 3 seconds
+        setInterval(() => {
+            fetch('{{.BaseURL}}/ui/audio')
+                .then(response => response.text())
+                .then(html => {
+                    // Only refresh if no slider is being dragged
+                    if (!document.querySelector('.volume-slider:active')) {
+                        const parser = new DOMParser();
+                        const doc = parser.parseFromString(html, 'text/html');
+                        const newChannels = doc.querySelectorAll('.audio-channel');
+
+                        newChannels.forEach(newChannel => {
+                            const inputName = newChannel.dataset.input;
+                            const oldChannel = document.querySelector('[data-input="' + inputName + '"]');
+                            if (oldChannel) {
+                                // Update mute state
+                                const wasMuted = oldChannel.classList.contains('muted');
+                                const isMuted = newChannel.classList.contains('muted');
+                                if (wasMuted !== isMuted) {
+                                    oldChannel.classList.toggle('muted', isMuted);
+                                    const btn = oldChannel.querySelector('.mute-toggle');
+                                    btn.classList.toggle('muted', isMuted);
+                                    btn.innerHTML = newChannel.querySelector('.mute-toggle').innerHTML;
+                                }
+
+                                // Update volume display (but not slider if user isn't touching it)
+                                const newDisplay = newChannel.querySelector('.volume-display').textContent;
+                                oldChannel.querySelector('.volume-display').textContent = newDisplay;
+                            }
+                        });
+                    }
+                });
+        }, 3000);
+
+        // Initial focus
+        if (channels.length > 0) setFocus(0);
+    </script>
+</body>
+</html>

--- a/internal/http/templates/error.html
+++ b/internal/http/templates/error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error</title>
+    <style>{{.SharedCSS}}</style>
+</head>
+<body>
+    <div class="container">
+        <h1><span class="accent">Error</span></h1>
+        <div class="error-message">
+            {{.Error}}
+        </div>
+    </div>
+</body>
+</html>

--- a/internal/http/templates/scene_preview.html
+++ b/internal/http/templates/scene_preview.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scene Preview</title>
+    <style>
+{{.SharedCSS}}
+
+.scene-card {
+    background: var(--bg-card);
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: all 0.2s;
+    border: 2px solid transparent;
+}
+
+.scene-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+}
+
+.scene-card.active {
+    border-color: var(--success);
+}
+
+.scene-card.active .current-badge {
+    display: inline-block;
+}
+
+.scene-thumbnail {
+    width: 100%;
+    height: 120px;
+    object-fit: cover;
+    background: var(--bg-primary);
+}
+
+.scene-info {
+    padding: 12px;
+}
+
+.scene-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.scene-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.current-badge {
+    display: none;
+    background: var(--success);
+    color: var(--bg-primary);
+    font-size: 0.65rem;
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.scene-meta {
+    display: flex;
+    gap: 12px;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.scene-meta span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.keyboard-hint {
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    margin-top: 20px;
+}
+
+.keyboard-hint kbd {
+    background: var(--bg-card);
+    padding: 2px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Scene <span class="accent">Preview</span></h1>
+
+        <div class="card">
+            <h2>Available Scenes ({{len .Scenes}})</h2>
+            <div class="scene-grid">
+                {{range .Scenes}}
+                <div class="scene-card {{if .IsCurrent}}active{{end}}" data-scene="{{.Name}}" tabindex="0">
+                    <img class="scene-thumbnail"
+                         src="{{.ThumbnailURL}}"
+                         alt="{{.Name}}"
+                         loading="lazy"
+                         onerror="this.style.display='none'">
+                    <div class="scene-info">
+                        <div class="scene-header">
+                            <span class="scene-name">{{.Name}}</span>
+                            <span class="current-badge">Live</span>
+                        </div>
+                        <div class="scene-meta">
+                            <span>Scene #{{.Index}}</span>
+                            <span>{{.SourceCount}} sources</span>
+                        </div>
+                    </div>
+                </div>
+                {{else}}
+                <p style="color: var(--text-secondary);">No scenes available</p>
+                {{end}}
+            </div>
+            <div class="keyboard-hint">
+                Press <kbd>1</kbd>-<kbd>9</kbd> to switch scenes, <kbd>Enter</kbd> to select focused
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let isLoading = false;
+
+        function switchScene(sceneName) {
+            if (isLoading) return;
+            isLoading = true;
+
+            // Add loading state to all cards
+            document.querySelectorAll('.scene-card').forEach(c => c.classList.add('loading'));
+
+            fetch('{{.BaseURL}}/ui/action', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    type: 'tool',
+                    messageId: 'scene-' + Date.now(),
+                    payload: { toolName: 'set_current_scene', params: { scene_name: sceneName } }
+                })
+            })
+            .then(response => {
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                return response.json();
+            })
+            .then(data => {
+                if (data.payload && data.payload.error) {
+                    alert('Error: ' + data.payload.error.message);
+                    isLoading = false;
+                    document.querySelectorAll('.scene-card').forEach(c => c.classList.remove('loading'));
+                } else {
+                    location.reload();
+                }
+            })
+            .catch(err => {
+                console.error('Scene switch failed:', err);
+                alert('Failed to switch scene: ' + err.message);
+                isLoading = false;
+                document.querySelectorAll('.scene-card').forEach(c => c.classList.remove('loading'));
+            });
+        }
+
+        // Click handling
+        document.querySelectorAll('.scene-card').forEach(card => {
+            card.addEventListener('click', () => {
+                const sceneName = card.dataset.scene;
+                if (sceneName) switchScene(sceneName);
+            });
+        });
+
+        // Keyboard handling
+        document.addEventListener('keydown', (e) => {
+            // Number keys 1-9 for quick switch
+            if (e.key >= '1' && e.key <= '9') {
+                const index = parseInt(e.key) - 1;
+                const cards = document.querySelectorAll('.scene-card');
+                if (cards[index]) {
+                    const sceneName = cards[index].dataset.scene;
+                    if (sceneName) switchScene(sceneName);
+                }
+            }
+
+            // Enter on focused card
+            if (e.key === 'Enter' && document.activeElement.classList.contains('scene-card')) {
+                const sceneName = document.activeElement.dataset.scene;
+                if (sceneName) switchScene(sceneName);
+            }
+
+            // Arrow key navigation
+            if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                const cards = Array.from(document.querySelectorAll('.scene-card'));
+                const current = cards.indexOf(document.activeElement);
+                if (current >= 0) {
+                    const next = e.key === 'ArrowRight' ? current + 1 : current - 1;
+                    if (cards[next]) cards[next].focus();
+                } else if (cards.length > 0) {
+                    cards[0].focus();
+                }
+            }
+        });
+
+        // Auto-refresh thumbnails every 10 seconds
+        setInterval(() => {
+            document.querySelectorAll('.scene-thumbnail').forEach(img => {
+                const url = new URL(img.src, location.href);
+                url.searchParams.set('t', Date.now());
+                img.src = url.toString();
+            });
+        }, 10000);
+    </script>
+</body>
+</html>

--- a/internal/http/templates/screenshot_gallery.html
+++ b/internal/http/templates/screenshot_gallery.html
@@ -27,12 +27,16 @@
     </div>
 
     <script>
-        // Auto-refresh images every 5 seconds
+        // Auto-refresh images every 5 seconds with error handling
         setInterval(() => {
             document.querySelectorAll('.screenshot-card img').forEach(img => {
                 const url = new URL(img.src, location.href);
                 url.searchParams.set('t', Date.now());
-                img.src = url.toString();
+                // Create a test image to check if the new URL loads
+                const testImg = new Image();
+                testImg.onload = () => { img.src = url.toString(); };
+                testImg.onerror = () => { console.warn('Screenshot refresh failed for:', url.pathname); };
+                testImg.src = url.toString();
             });
         }, 5000);
     </script>

--- a/internal/http/templates/screenshot_gallery.html
+++ b/internal/http/templates/screenshot_gallery.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Screenshot Gallery</title>
+    <style>{{.SharedCSS}}</style>
+</head>
+<body>
+    <div class="container">
+        <h1>Screenshot <span class="accent">Gallery</span></h1>
+
+        <div class="screenshot-grid">
+            {{range .Sources}}
+            <div class="screenshot-card">
+                <img src="{{.ImageURL}}" alt="{{.Name}}" onerror="this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22300%22 height=%22180%22><rect fill=%22%231a1a2e%22 width=%22300%22 height=%22180%22/><text fill=%22%23666%22 x=%2250%%22 y=%2250%%22 text-anchor=%22middle%22>No Image</text></svg>'">
+                <div class="info">
+                    <div class="name">{{.Name}}</div>
+                    <div class="meta">Source: {{.SourceName}} | Cadence: {{.CadenceMs}}ms</div>
+                    <div class="meta">Last: {{.LastCapture}}</div>
+                </div>
+            </div>
+            {{else}}
+            <p style="color: var(--text-secondary);">No screenshot sources configured</p>
+            {{end}}
+        </div>
+    </div>
+
+    <script>
+        // Auto-refresh images every 5 seconds
+        setInterval(() => {
+            document.querySelectorAll('.screenshot-card img').forEach(img => {
+                const url = new URL(img.src, location.href);
+                url.searchParams.set('t', Date.now());
+                img.src = url.toString();
+            });
+        }, 5000);
+    </script>
+</body>
+</html>

--- a/internal/http/templates/shared.css
+++ b/internal/http/templates/shared.css
@@ -1,0 +1,274 @@
+/* Shared CSS for MCP-UI templates - matches existing dashboard theme */
+:root {
+    --bg-primary: #1a1a2e;
+    --bg-secondary: #16213e;
+    --bg-card: #0f3460;
+    --text-primary: #eaeaea;
+    --text-secondary: #a0a0a0;
+    --accent: #e94560;
+    --accent-hover: #ff6b6b;
+    --success: #4ecca3;
+    --warning: #ffc107;
+    --error: #ff6b6b;
+    --border: #2a2a4a;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    padding: 20px;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+    color: var(--text-primary);
+}
+
+h1 .accent {
+    color: var(--accent);
+}
+
+.card {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 20px;
+    margin-bottom: 20px;
+    border: 1px solid var(--border);
+}
+
+.card h2 {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    margin-bottom: 15px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+.status-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.status-item:last-child {
+    border-bottom: none;
+}
+
+.status-label {
+    color: var(--text-secondary);
+}
+
+.status-value {
+    font-weight: 500;
+}
+
+.status-value.success {
+    color: var(--success);
+}
+
+.status-value.error {
+    color: var(--error);
+}
+
+.status-value.warning {
+    color: var(--warning);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-size: 0.875rem;
+}
+
+.badge.online {
+    background: rgba(78, 204, 163, 0.15);
+    color: var(--success);
+}
+
+.badge.offline {
+    background: rgba(255, 107, 107, 0.15);
+    color: var(--error);
+}
+
+.badge .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.btn {
+    background: var(--accent);
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background 0.2s;
+}
+
+.btn:hover {
+    background: var(--accent-hover);
+}
+
+.btn.secondary {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+}
+
+.btn.secondary:hover {
+    background: var(--border);
+}
+
+.scene-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 15px;
+}
+
+.scene-card {
+    background: var(--bg-card);
+    border-radius: 8px;
+    padding: 15px;
+    cursor: pointer;
+    transition: all 0.2s;
+    border: 2px solid transparent;
+}
+
+.scene-card:hover {
+    border-color: var(--accent);
+}
+
+.scene-card.active {
+    border-color: var(--success);
+    background: rgba(78, 204, 163, 0.1);
+}
+
+.scene-card .name {
+    font-weight: 500;
+    margin-bottom: 5px;
+}
+
+.scene-card .index {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.slider-container {
+    padding: 15px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.slider-container:last-child {
+    border-bottom: none;
+}
+
+.slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.slider-name {
+    font-weight: 500;
+}
+
+.slider-value {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+input[type="range"] {
+    width: 100%;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--bg-card);
+    -webkit-appearance: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+}
+
+.mute-btn {
+    padding: 6px 12px;
+    font-size: 0.75rem;
+}
+
+.mute-btn.muted {
+    background: var(--error);
+}
+
+.screenshot-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.screenshot-card {
+    background: var(--bg-card);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.screenshot-card img {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+    background: var(--bg-primary);
+}
+
+.screenshot-card .info {
+    padding: 15px;
+}
+
+.screenshot-card .name {
+    font-weight: 500;
+    margin-bottom: 5px;
+}
+
+.screenshot-card .meta {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.error-message {
+    background: rgba(255, 107, 107, 0.1);
+    border: 1px solid var(--error);
+    color: var(--error);
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}

--- a/internal/http/templates/status_dashboard.html
+++ b/internal/http/templates/status_dashboard.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OBS Status Dashboard</title>
+    <style>{{.SharedCSS}}</style>
+</head>
+<body>
+    <div class="container">
+        <h1><span class="accent">agentic-obs</span> Status</h1>
+
+        <div class="grid">
+            <div class="card">
+                <h2>Connection</h2>
+                <div class="status-item">
+                    <span class="status-label">OBS WebSocket</span>
+                    <span class="badge online"><span class="dot"></span> Connected</span>
+                </div>
+            </div>
+
+            <div class="card">
+                <h2>Recording</h2>
+                <div class="status-item">
+                    <span class="status-label">Status</span>
+                    <span class="status-value">Idle</span>
+                </div>
+            </div>
+
+            <div class="card">
+                <h2>Streaming</h2>
+                <div class="status-item">
+                    <span class="status-label">Status</span>
+                    <span class="status-value">Offline</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>Scenes ({{len .Scenes}})</h2>
+            <div class="scene-grid">
+                {{range .Scenes}}
+                <div class="scene-card {{if .IsCurrent}}active{{end}}" data-scene="{{.Name}}">
+                    <div class="name">{{.Name}}</div>
+                    <div class="index">Scene #{{.Index}}</div>
+                </div>
+                {{else}}
+                <p style="color: var(--text-secondary);">No scenes available</p>
+                {{end}}
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // UIAction helper for scene switching
+        document.querySelectorAll('.scene-card').forEach(card => {
+            card.addEventListener('click', () => {
+                const sceneName = card.dataset.scene;
+                if (!sceneName) return;
+
+                // Send UIAction to parent
+                const action = {
+                    type: 'tool',
+                    messageId: 'scene-' + Date.now(),
+                    payload: {
+                        toolName: 'set_current_scene',
+                        params: { scene_name: sceneName }
+                    }
+                };
+
+                // Post to action endpoint
+                fetch('{{.BaseURL}}/ui/action', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(action)
+                }).then(() => {
+                    // Refresh to show updated state
+                    location.reload();
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/internal/http/ui_handlers.go
+++ b/internal/http/ui_handlers.go
@@ -1448,4 +1448,3 @@ var errorTemplate = `<!DOCTYPE html>
     </div>
 </body>
 </html>`
-

--- a/internal/http/ui_handlers.go
+++ b/internal/http/ui_handlers.go
@@ -1,0 +1,751 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+)
+
+// StatusProvider interface for getting OBS status data.
+// This allows the HTTP server to fetch status without direct OBS dependency.
+type StatusProvider interface {
+	// GetStatus returns the current OBS status as a JSON-serializable struct.
+	GetStatus() (any, error)
+	// GetScenes returns a list of scenes.
+	GetScenes() ([]SceneInfo, error)
+	// GetAudioInputs returns a list of audio inputs with their current state.
+	GetAudioInputs() ([]AudioInputInfo, error)
+	// GetScreenshotSources returns a list of screenshot sources.
+	GetScreenshotSources() ([]ScreenshotSourceInfo, error)
+}
+
+// SceneInfo represents a scene for UI display.
+type SceneInfo struct {
+	Name      string `json:"name"`
+	Index     int    `json:"index"`
+	IsCurrent bool   `json:"isCurrent"`
+}
+
+// AudioInputInfo represents an audio input for UI display.
+type AudioInputInfo struct {
+	Name          string  `json:"name"`
+	Volume        float64 `json:"volume"`        // 0.0-1.0
+	VolumePercent float64 `json:"volumePercent"` // 0-100 for slider
+	VolumeDB      float64 `json:"volumeDb"`      // in dB
+	IsMuted       bool    `json:"isMuted"`
+	InputKind     string  `json:"inputKind"`
+}
+
+// ScreenshotSourceInfo represents a screenshot source for UI display.
+type ScreenshotSourceInfo struct {
+	Name        string `json:"name"`
+	SourceName  string `json:"sourceName"`
+	CadenceMs   int    `json:"cadenceMs"`
+	ImageURL    string `json:"imageUrl"`
+	LastCapture string `json:"lastCapture"`
+}
+
+// UIHandlers provides HTTP handlers for MCP-UI resources.
+type UIHandlers struct {
+	statusProvider StatusProvider
+	baseURL        string
+}
+
+// NewUIHandlers creates a new UIHandlers instance.
+func NewUIHandlers(provider StatusProvider, baseURL string) *UIHandlers {
+	return &UIHandlers{
+		statusProvider: provider,
+		baseURL:        baseURL,
+	}
+}
+
+// HandleUIStatus serves the status dashboard UI.
+func (h *UIHandlers) HandleUIStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Get current status
+	status, err := h.statusProvider.GetStatus()
+	if err != nil {
+		h.renderError(w, "Failed to get OBS status", err)
+		return
+	}
+
+	// Get scenes
+	scenes, err := h.statusProvider.GetScenes()
+	if err != nil {
+		scenes = []SceneInfo{} // Empty on error, show what we can
+	}
+
+	data := map[string]any{
+		"Status":  status,
+		"Scenes":  scenes,
+		"BaseURL": h.baseURL,
+	}
+
+	h.renderTemplate(w, statusDashboardTemplate, data)
+}
+
+// HandleUIScenes serves the scene preview UI.
+func (h *UIHandlers) HandleUIScenes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	scenes, err := h.statusProvider.GetScenes()
+	if err != nil {
+		h.renderError(w, "Failed to get scenes", err)
+		return
+	}
+
+	data := map[string]any{
+		"Scenes":  scenes,
+		"BaseURL": h.baseURL,
+	}
+
+	h.renderTemplate(w, scenePreviewTemplate, data)
+}
+
+// HandleUIAudio serves the audio mixer UI.
+func (h *UIHandlers) HandleUIAudio(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	inputs, err := h.statusProvider.GetAudioInputs()
+	if err != nil {
+		h.renderError(w, "Failed to get audio inputs", err)
+		return
+	}
+
+	data := map[string]any{
+		"Inputs":  inputs,
+		"BaseURL": h.baseURL,
+	}
+
+	h.renderTemplate(w, audioMixerTemplate, data)
+}
+
+// HandleUIScreenshots serves the screenshot gallery UI.
+func (h *UIHandlers) HandleUIScreenshots(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sources, err := h.statusProvider.GetScreenshotSources()
+	if err != nil {
+		h.renderError(w, "Failed to get screenshot sources", err)
+		return
+	}
+
+	data := map[string]any{
+		"Sources": sources,
+		"BaseURL": h.baseURL,
+	}
+
+	h.renderTemplate(w, screenshotGalleryTemplate, data)
+}
+
+// HandleUIAction handles UIAction requests from embedded UIs.
+// POST /ui/action - receives UIAction JSON, executes, returns UIResponse.
+func (h *UIHandlers) HandleUIAction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var action struct {
+		Type      string          `json:"type"`
+		MessageID string          `json:"messageId"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&action); err != nil {
+		h.jsonError(w, "Invalid action format", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Route action to appropriate handler based on type
+	// For now, return acknowledgment
+	response := map[string]any{
+		"type":      "ui-message-received",
+		"messageId": action.MessageID,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *UIHandlers) renderTemplate(w http.ResponseWriter, tmpl string, data any) {
+	t, err := template.New("ui").Parse(tmpl)
+	if err != nil {
+		http.Error(w, "Template error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := t.Execute(w, data); err != nil {
+		// Headers already sent, just log
+		fmt.Printf("Template execution error: %v\n", err)
+	}
+}
+
+func (h *UIHandlers) renderError(w http.ResponseWriter, message string, err error) {
+	errMsg := message
+	if err != nil {
+		errMsg = fmt.Sprintf("%s: %v", message, err)
+	}
+
+	data := map[string]any{
+		"Error": errMsg,
+	}
+	h.renderTemplate(w, errorTemplate, data)
+}
+
+func (h *UIHandlers) jsonError(w http.ResponseWriter, message string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+// CSS shared across all UI templates - matches existing dashboard theme
+const sharedCSS = `
+:root {
+    --bg-primary: #1a1a2e;
+    --bg-secondary: #16213e;
+    --bg-card: #0f3460;
+    --text-primary: #eaeaea;
+    --text-secondary: #a0a0a0;
+    --accent: #e94560;
+    --accent-hover: #ff6b6b;
+    --success: #4ecca3;
+    --warning: #ffc107;
+    --error: #ff6b6b;
+    --border: #2a2a4a;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    padding: 20px;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+    color: var(--text-primary);
+}
+
+h1 .accent {
+    color: var(--accent);
+}
+
+.card {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 20px;
+    margin-bottom: 20px;
+    border: 1px solid var(--border);
+}
+
+.card h2 {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    margin-bottom: 15px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+.status-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.status-item:last-child {
+    border-bottom: none;
+}
+
+.status-label {
+    color: var(--text-secondary);
+}
+
+.status-value {
+    font-weight: 500;
+}
+
+.status-value.success {
+    color: var(--success);
+}
+
+.status-value.error {
+    color: var(--error);
+}
+
+.status-value.warning {
+    color: var(--warning);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-size: 0.875rem;
+}
+
+.badge.online {
+    background: rgba(78, 204, 163, 0.15);
+    color: var(--success);
+}
+
+.badge.offline {
+    background: rgba(255, 107, 107, 0.15);
+    color: var(--error);
+}
+
+.badge .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.btn {
+    background: var(--accent);
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background 0.2s;
+}
+
+.btn:hover {
+    background: var(--accent-hover);
+}
+
+.btn.secondary {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+}
+
+.btn.secondary:hover {
+    background: var(--border);
+}
+
+.scene-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 15px;
+}
+
+.scene-card {
+    background: var(--bg-card);
+    border-radius: 8px;
+    padding: 15px;
+    cursor: pointer;
+    transition: all 0.2s;
+    border: 2px solid transparent;
+}
+
+.scene-card:hover {
+    border-color: var(--accent);
+}
+
+.scene-card.active {
+    border-color: var(--success);
+    background: rgba(78, 204, 163, 0.1);
+}
+
+.scene-card .name {
+    font-weight: 500;
+    margin-bottom: 5px;
+}
+
+.scene-card .index {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.slider-container {
+    padding: 15px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.slider-container:last-child {
+    border-bottom: none;
+}
+
+.slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.slider-name {
+    font-weight: 500;
+}
+
+.slider-value {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+input[type="range"] {
+    width: 100%;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--bg-card);
+    -webkit-appearance: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+}
+
+.mute-btn {
+    padding: 6px 12px;
+    font-size: 0.75rem;
+}
+
+.mute-btn.muted {
+    background: var(--error);
+}
+
+.screenshot-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.screenshot-card {
+    background: var(--bg-card);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.screenshot-card img {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+    background: var(--bg-primary);
+}
+
+.screenshot-card .info {
+    padding: 15px;
+}
+
+.screenshot-card .name {
+    font-weight: 500;
+    margin-bottom: 5px;
+}
+
+.screenshot-card .meta {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.error-message {
+    background: rgba(255, 107, 107, 0.1);
+    border: 1px solid var(--error);
+    color: var(--error);
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+`
+
+// Status Dashboard Template
+var statusDashboardTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OBS Status Dashboard</title>
+    <style>` + sharedCSS + `</style>
+</head>
+<body>
+    <div class="container">
+        <h1><span class="accent">agentic-obs</span> Status</h1>
+
+        <div class="grid">
+            <div class="card">
+                <h2>Connection</h2>
+                <div class="status-item">
+                    <span class="status-label">OBS WebSocket</span>
+                    <span class="badge online"><span class="dot"></span> Connected</span>
+                </div>
+            </div>
+
+            <div class="card">
+                <h2>Recording</h2>
+                <div class="status-item">
+                    <span class="status-label">Status</span>
+                    <span class="status-value">Idle</span>
+                </div>
+            </div>
+
+            <div class="card">
+                <h2>Streaming</h2>
+                <div class="status-item">
+                    <span class="status-label">Status</span>
+                    <span class="status-value">Offline</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>Scenes ({{len .Scenes}})</h2>
+            <div class="scene-grid">
+                {{range .Scenes}}
+                <div class="scene-card {{if .IsCurrent}}active{{end}}" data-scene="{{.Name}}">
+                    <div class="name">{{.Name}}</div>
+                    <div class="index">Scene #{{.Index}}</div>
+                </div>
+                {{else}}
+                <p style="color: var(--text-secondary);">No scenes available</p>
+                {{end}}
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // UIAction helper for scene switching
+        document.querySelectorAll('.scene-card').forEach(card => {
+            card.addEventListener('click', () => {
+                const sceneName = card.dataset.scene;
+                if (!sceneName) return;
+
+                // Send UIAction to parent
+                const action = {
+                    type: 'tool',
+                    messageId: 'scene-' + Date.now(),
+                    payload: {
+                        toolName: 'set_current_scene',
+                        params: { scene_name: sceneName }
+                    }
+                };
+
+                // Post to action endpoint
+                fetch('{{.BaseURL}}/ui/action', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(action)
+                }).then(() => {
+                    // Refresh to show updated state
+                    location.reload();
+                });
+            });
+        });
+    </script>
+</body>
+</html>`
+
+// Scene Preview Template
+var scenePreviewTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scene Preview</title>
+    <style>` + sharedCSS + `</style>
+</head>
+<body>
+    <div class="container">
+        <h1>Scene <span class="accent">Preview</span></h1>
+
+        <div class="card">
+            <h2>Available Scenes</h2>
+            <div class="scene-grid">
+                {{range .Scenes}}
+                <div class="scene-card {{if .IsCurrent}}active{{end}}" data-scene="{{.Name}}">
+                    <div class="name">{{.Name}}</div>
+                    <div class="index">Scene #{{.Index}}</div>
+                </div>
+                {{else}}
+                <p style="color: var(--text-secondary);">No scenes available</p>
+                {{end}}
+            </div>
+        </div>
+    </div>
+
+    <script>
+        document.querySelectorAll('.scene-card').forEach(card => {
+            card.addEventListener('click', () => {
+                const sceneName = card.dataset.scene;
+                if (!sceneName) return;
+
+                fetch('{{.BaseURL}}/ui/action', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        type: 'tool',
+                        messageId: 'scene-' + Date.now(),
+                        payload: { toolName: 'set_current_scene', params: { scene_name: sceneName } }
+                    })
+                }).then(() => location.reload());
+            });
+        });
+    </script>
+</body>
+</html>`
+
+// Audio Mixer Template
+var audioMixerTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Audio Mixer</title>
+    <style>` + sharedCSS + `</style>
+</head>
+<body>
+    <div class="container">
+        <h1>Audio <span class="accent">Mixer</span></h1>
+
+        <div class="card">
+            <h2>Audio Inputs</h2>
+            {{range .Inputs}}
+            <div class="slider-container" data-input="{{.Name}}">
+                <div class="slider-header">
+                    <span class="slider-name">{{.Name}}</span>
+                    <span class="slider-value">{{printf "%.1f" .VolumeDB}} dB</span>
+                    <button class="btn mute-btn {{if .IsMuted}}muted{{end}}" onclick="toggleMute('{{.Name}}')">
+                        {{if .IsMuted}}Unmute{{else}}Mute{{end}}
+                    </button>
+                </div>
+                <input type="range" min="0" max="100" value="{{printf "%.0f" .VolumePercent}}"
+                       onchange="setVolume('{{.Name}}', this.value)">
+            </div>
+            {{else}}
+            <p style="color: var(--text-secondary);">No audio inputs available</p>
+            {{end}}
+        </div>
+    </div>
+
+    <script>
+        function toggleMute(inputName) {
+            fetch('{{.BaseURL}}/ui/action', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    type: 'tool',
+                    messageId: 'mute-' + Date.now(),
+                    payload: { toolName: 'toggle_input_mute', params: { input_name: inputName } }
+                })
+            }).then(() => location.reload());
+        }
+
+        function setVolume(inputName, value) {
+            const db = (value / 100) * 26 - 26; // Map 0-100 to -26 to 0 dB
+            fetch('{{.BaseURL}}/ui/action', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    type: 'tool',
+                    messageId: 'vol-' + Date.now(),
+                    payload: { toolName: 'set_input_volume', params: { input_name: inputName, volume_db: db } }
+                })
+            });
+        }
+    </script>
+</body>
+</html>`
+
+// Screenshot Gallery Template
+var screenshotGalleryTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Screenshot Gallery</title>
+    <style>` + sharedCSS + `</style>
+</head>
+<body>
+    <div class="container">
+        <h1>Screenshot <span class="accent">Gallery</span></h1>
+
+        <div class="screenshot-grid">
+            {{range .Sources}}
+            <div class="screenshot-card">
+                <img src="{{.ImageURL}}" alt="{{.Name}}" onerror="this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22300%22 height=%22180%22><rect fill=%22%231a1a2e%22 width=%22300%22 height=%22180%22/><text fill=%22%23666%22 x=%2250%%22 y=%2250%%22 text-anchor=%22middle%22>No Image</text></svg>'">
+                <div class="info">
+                    <div class="name">{{.Name}}</div>
+                    <div class="meta">Source: {{.SourceName}} | Cadence: {{.CadenceMs}}ms</div>
+                    <div class="meta">Last: {{.LastCapture}}</div>
+                </div>
+            </div>
+            {{else}}
+            <p style="color: var(--text-secondary);">No screenshot sources configured</p>
+            {{end}}
+        </div>
+    </div>
+
+    <script>
+        // Auto-refresh images every 5 seconds
+        setInterval(() => {
+            document.querySelectorAll('.screenshot-card img').forEach(img => {
+                const url = new URL(img.src, location.href);
+                url.searchParams.set('t', Date.now());
+                img.src = url.toString();
+            });
+        }, 5000);
+    </script>
+</body>
+</html>`
+
+// Error Template
+var errorTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error</title>
+    <style>` + sharedCSS + `</style>
+</head>
+<body>
+    <div class="container">
+        <h1><span class="accent">Error</span></h1>
+        <div class="error-message">
+            {{.Error}}
+        </div>
+    </div>
+</body>
+</html>`
+

--- a/internal/http/ui_handlers_test.go
+++ b/internal/http/ui_handlers_test.go
@@ -40,6 +40,49 @@ func (m *mockStatusProvider) GetScreenshotSources() ([]ScreenshotSourceInfo, err
 	return m.screenshotSources, m.screenshotErr
 }
 
+// mockActionExecutor implements ActionExecutor for testing
+type mockActionExecutor struct {
+	setSceneErr      error
+	setSceneCalled   string
+	toggleMuteErr    error
+	toggleMuteCalled string
+	setVolumeErr     error
+	setVolumeCalled  struct {
+		name     string
+		volumeDb float64
+	}
+	thumbnailData     []byte
+	thumbnailMimeType string
+	thumbnailErr      error
+}
+
+func (m *mockActionExecutor) SetCurrentScene(sceneName string) error {
+	m.setSceneCalled = sceneName
+	return m.setSceneErr
+}
+
+func (m *mockActionExecutor) ToggleInputMute(inputName string) error {
+	m.toggleMuteCalled = inputName
+	return m.toggleMuteErr
+}
+
+func (m *mockActionExecutor) SetInputVolume(inputName string, volumeDb float64) error {
+	m.setVolumeCalled.name = inputName
+	m.setVolumeCalled.volumeDb = volumeDb
+	return m.setVolumeErr
+}
+
+func (m *mockActionExecutor) TakeSceneThumbnail(sceneName string) ([]byte, string, error) {
+	if m.thumbnailErr != nil {
+		return nil, "", m.thumbnailErr
+	}
+	if m.thumbnailData != nil {
+		return m.thumbnailData, m.thumbnailMimeType, nil
+	}
+	// Return simple placeholder
+	return []byte("<svg></svg>"), "image/svg+xml", nil
+}
+
 func TestHandleUIStatus(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -444,4 +487,195 @@ func TestNewUIHandlers(t *testing.T) {
 	assert.NotNil(t, handlers)
 	assert.Equal(t, "http://example.com:9000", handlers.baseURL)
 	assert.Equal(t, provider, handlers.statusProvider)
+}
+
+func TestSetActionExecutor(t *testing.T) {
+	handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+	executor := &mockActionExecutor{}
+
+	handlers.SetActionExecutor(executor)
+
+	assert.Equal(t, executor, handlers.actionExecutor)
+}
+
+func TestHandleSceneThumbnail(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		executor       *mockActionExecutor
+		wantStatus     int
+		wantType       string
+		wantContains   string
+	}{
+		{
+			name:       "returns thumbnail image",
+			method:     http.MethodGet,
+			path:       "/ui/scene-thumbnail/Gaming",
+			executor:   &mockActionExecutor{thumbnailData: []byte{0x89, 0x50, 0x4E, 0x47}, thumbnailMimeType: "image/png"},
+			wantStatus: http.StatusOK,
+			wantType:   "image/png",
+		},
+		{
+			name:       "returns SVG placeholder when no executor",
+			method:     http.MethodGet,
+			path:       "/ui/scene-thumbnail/Gaming",
+			executor:   nil,
+			wantStatus: http.StatusOK,
+			wantType:   "image/svg+xml",
+			wantContains: "Gaming",
+		},
+		{
+			name:       "returns SVG placeholder on error",
+			method:     http.MethodGet,
+			path:       "/ui/scene-thumbnail/Gaming",
+			executor:   &mockActionExecutor{thumbnailErr: errors.New("screenshot failed")},
+			wantStatus: http.StatusOK,
+			wantType:   "image/svg+xml",
+		},
+		{
+			name:       "rejects POST method",
+			method:     http.MethodPost,
+			path:       "/ui/scene-thumbnail/Gaming",
+			executor:   nil,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "rejects missing scene name",
+			method:     http.MethodGet,
+			path:       "/ui/scene-thumbnail/",
+			executor:   nil,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+			if tt.executor != nil {
+				handlers.SetActionExecutor(tt.executor)
+			}
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rec := httptest.NewRecorder()
+
+			handlers.HandleSceneThumbnail(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			if tt.wantType != "" {
+				assert.Equal(t, tt.wantType, rec.Header().Get("Content-Type"))
+			}
+			if tt.wantContains != "" {
+				assert.Contains(t, rec.Body.String(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestHandleUIActionWithExecutor(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		executor     *mockActionExecutor
+		wantStatus   int
+		wantType     string
+		wantSuccess  bool
+		wantError    bool
+	}{
+		{
+			name: "executes set_current_scene successfully",
+			body: `{"type":"tool","messageId":"msg-1","payload":{"toolName":"set_current_scene","params":{"scene_name":"Gaming"}}}`,
+			executor: &mockActionExecutor{},
+			wantStatus: http.StatusOK,
+			wantType:   "ui-message-response",
+			wantSuccess: true,
+		},
+		{
+			name: "returns error when set_current_scene fails",
+			body: `{"type":"tool","messageId":"msg-2","payload":{"toolName":"set_current_scene","params":{"scene_name":"Invalid"}}}`,
+			executor: &mockActionExecutor{setSceneErr: errors.New("scene not found")},
+			wantStatus: http.StatusOK,
+			wantType:   "ui-message-response",
+			wantError: true,
+		},
+		{
+			name: "executes toggle_input_mute successfully",
+			body: `{"type":"tool","messageId":"msg-3","payload":{"toolName":"toggle_input_mute","params":{"input_name":"Mic"}}}`,
+			executor: &mockActionExecutor{},
+			wantStatus: http.StatusOK,
+			wantType:   "ui-message-response",
+			wantSuccess: true,
+		},
+		{
+			name: "executes set_input_volume successfully",
+			body: `{"type":"tool","messageId":"msg-4","payload":{"toolName":"set_input_volume","params":{"input_name":"Mic","volume_db":-10.0}}}`,
+			executor: &mockActionExecutor{},
+			wantStatus: http.StatusOK,
+			wantType:   "ui-message-response",
+			wantSuccess: true,
+		},
+		{
+			name: "returns error for unsupported tool",
+			body: `{"type":"tool","messageId":"msg-5","payload":{"toolName":"unknown_tool","params":{}}}`,
+			executor: &mockActionExecutor{},
+			wantStatus: http.StatusOK,
+			wantType:   "ui-message-response",
+			wantError: true,
+		},
+		{
+			name: "returns error for missing parameters",
+			body: `{"type":"tool","messageId":"msg-6","payload":{"toolName":"set_current_scene","params":{}}}`,
+			executor: &mockActionExecutor{},
+			wantStatus: http.StatusOK,
+			wantType:   "ui-message-response",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+			handlers.SetActionExecutor(tt.executor)
+
+			req := httptest.NewRequest(http.MethodPost, "/ui/action", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handlers.HandleUIAction(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			var response map[string]any
+			err := json.NewDecoder(rec.Body).Decode(&response)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantType, response["type"])
+
+			if tt.wantSuccess {
+				payload := response["payload"].(map[string]any)
+				assert.NotNil(t, payload["response"])
+			}
+			if tt.wantError {
+				payload := response["payload"].(map[string]any)
+				assert.NotNil(t, payload["error"])
+			}
+		})
+	}
+}
+
+func TestSceneInfoEnhancements(t *testing.T) {
+	// Test that SceneInfo includes new fields
+	scene := SceneInfo{
+		Name:         "Main",
+		Index:        0,
+		IsCurrent:    true,
+		SourceCount:  5,
+		ThumbnailURL: "http://localhost:8765/ui/scene-thumbnail/Main",
+	}
+
+	assert.Equal(t, "Main", scene.Name)
+	assert.Equal(t, 0, scene.Index)
+	assert.True(t, scene.IsCurrent)
+	assert.Equal(t, 5, scene.SourceCount)
+	assert.Equal(t, "http://localhost:8765/ui/scene-thumbnail/Main", scene.ThumbnailURL)
 }

--- a/internal/http/ui_handlers_test.go
+++ b/internal/http/ui_handlers_test.go
@@ -364,7 +364,7 @@ func TestHandleUIAction(t *testing.T) {
 		wantResponse map[string]any
 	}{
 		{
-			name:   "acknowledges tool action",
+			name:   "returns error for tool action without executor",
 			method: http.MethodPost,
 			body: `{
 				"type": "tool",
@@ -373,7 +373,7 @@ func TestHandleUIAction(t *testing.T) {
 			}`,
 			wantStatus: http.StatusOK,
 			wantResponse: map[string]any{
-				"type":      "ui-message-received",
+				"type":      "ui-message-response",
 				"messageId": "msg-123",
 			},
 		},

--- a/internal/http/ui_handlers_test.go
+++ b/internal/http/ui_handlers_test.go
@@ -123,7 +123,7 @@ func TestHandleUIStatus(t *testing.T) {
 			name:   "shows empty scenes when scenes fail",
 			method: http.MethodGet,
 			provider: &mockStatusProvider{
-				status: map[string]any{"connected": true},
+				status:    map[string]any{"connected": true},
 				scenesErr: errors.New("scenes error"),
 			},
 			wantStatus:   http.StatusOK,
@@ -442,9 +442,9 @@ func TestUIHandlersContentType(t *testing.T) {
 	handlers := NewUIHandlers(provider, "http://localhost:8765")
 
 	tests := []struct {
-		name        string
-		handler     func(http.ResponseWriter, *http.Request)
-		wantType    string
+		name     string
+		handler  func(http.ResponseWriter, *http.Request)
+		wantType string
 	}{
 		{
 			name:     "status returns HTML",
@@ -500,13 +500,13 @@ func TestSetActionExecutor(t *testing.T) {
 
 func TestHandleSceneThumbnail(t *testing.T) {
 	tests := []struct {
-		name           string
-		method         string
-		path           string
-		executor       *mockActionExecutor
-		wantStatus     int
-		wantType       string
-		wantContains   string
+		name         string
+		method       string
+		path         string
+		executor     *mockActionExecutor
+		wantStatus   int
+		wantType     string
+		wantContains string
 	}{
 		{
 			name:       "returns thumbnail image",
@@ -517,12 +517,12 @@ func TestHandleSceneThumbnail(t *testing.T) {
 			wantType:   "image/png",
 		},
 		{
-			name:       "returns SVG placeholder when no executor",
-			method:     http.MethodGet,
-			path:       "/ui/scene-thumbnail/Gaming",
-			executor:   nil,
-			wantStatus: http.StatusOK,
-			wantType:   "image/svg+xml",
+			name:         "returns SVG placeholder when no executor",
+			method:       http.MethodGet,
+			path:         "/ui/scene-thumbnail/Gaming",
+			executor:     nil,
+			wantStatus:   http.StatusOK,
+			wantType:     "image/svg+xml",
 			wantContains: "Gaming",
 		},
 		{
@@ -574,61 +574,61 @@ func TestHandleSceneThumbnail(t *testing.T) {
 
 func TestHandleUIActionWithExecutor(t *testing.T) {
 	tests := []struct {
-		name         string
-		body         string
-		executor     *mockActionExecutor
-		wantStatus   int
-		wantType     string
-		wantSuccess  bool
-		wantError    bool
+		name        string
+		body        string
+		executor    *mockActionExecutor
+		wantStatus  int
+		wantType    string
+		wantSuccess bool
+		wantError   bool
 	}{
 		{
-			name: "executes set_current_scene successfully",
-			body: `{"type":"tool","messageId":"msg-1","payload":{"toolName":"set_current_scene","params":{"scene_name":"Gaming"}}}`,
-			executor: &mockActionExecutor{},
-			wantStatus: http.StatusOK,
-			wantType:   "ui-message-response",
+			name:        "executes set_current_scene successfully",
+			body:        `{"type":"tool","messageId":"msg-1","payload":{"toolName":"set_current_scene","params":{"scene_name":"Gaming"}}}`,
+			executor:    &mockActionExecutor{},
+			wantStatus:  http.StatusOK,
+			wantType:    "ui-message-response",
 			wantSuccess: true,
 		},
 		{
-			name: "returns error when set_current_scene fails",
-			body: `{"type":"tool","messageId":"msg-2","payload":{"toolName":"set_current_scene","params":{"scene_name":"Invalid"}}}`,
-			executor: &mockActionExecutor{setSceneErr: errors.New("scene not found")},
+			name:       "returns error when set_current_scene fails",
+			body:       `{"type":"tool","messageId":"msg-2","payload":{"toolName":"set_current_scene","params":{"scene_name":"Invalid"}}}`,
+			executor:   &mockActionExecutor{setSceneErr: errors.New("scene not found")},
 			wantStatus: http.StatusOK,
 			wantType:   "ui-message-response",
-			wantError: true,
+			wantError:  true,
 		},
 		{
-			name: "executes toggle_input_mute successfully",
-			body: `{"type":"tool","messageId":"msg-3","payload":{"toolName":"toggle_input_mute","params":{"input_name":"Mic"}}}`,
-			executor: &mockActionExecutor{},
-			wantStatus: http.StatusOK,
-			wantType:   "ui-message-response",
+			name:        "executes toggle_input_mute successfully",
+			body:        `{"type":"tool","messageId":"msg-3","payload":{"toolName":"toggle_input_mute","params":{"input_name":"Mic"}}}`,
+			executor:    &mockActionExecutor{},
+			wantStatus:  http.StatusOK,
+			wantType:    "ui-message-response",
 			wantSuccess: true,
 		},
 		{
-			name: "executes set_input_volume successfully",
-			body: `{"type":"tool","messageId":"msg-4","payload":{"toolName":"set_input_volume","params":{"input_name":"Mic","volume_db":-10.0}}}`,
-			executor: &mockActionExecutor{},
-			wantStatus: http.StatusOK,
-			wantType:   "ui-message-response",
+			name:        "executes set_input_volume successfully",
+			body:        `{"type":"tool","messageId":"msg-4","payload":{"toolName":"set_input_volume","params":{"input_name":"Mic","volume_db":-10.0}}}`,
+			executor:    &mockActionExecutor{},
+			wantStatus:  http.StatusOK,
+			wantType:    "ui-message-response",
 			wantSuccess: true,
 		},
 		{
-			name: "returns error for unsupported tool",
-			body: `{"type":"tool","messageId":"msg-5","payload":{"toolName":"unknown_tool","params":{}}}`,
-			executor: &mockActionExecutor{},
+			name:       "returns error for unsupported tool",
+			body:       `{"type":"tool","messageId":"msg-5","payload":{"toolName":"unknown_tool","params":{}}}`,
+			executor:   &mockActionExecutor{},
 			wantStatus: http.StatusOK,
 			wantType:   "ui-message-response",
-			wantError: true,
+			wantError:  true,
 		},
 		{
-			name: "returns error for missing parameters",
-			body: `{"type":"tool","messageId":"msg-6","payload":{"toolName":"set_current_scene","params":{}}}`,
-			executor: &mockActionExecutor{},
+			name:       "returns error for missing parameters",
+			body:       `{"type":"tool","messageId":"msg-6","payload":{"toolName":"set_current_scene","params":{}}}`,
+			executor:   &mockActionExecutor{},
 			wantStatus: http.StatusOK,
 			wantType:   "ui-message-response",
-			wantError: true,
+			wantError:  true,
 		},
 	}
 

--- a/internal/http/ui_handlers_test.go
+++ b/internal/http/ui_handlers_test.go
@@ -1,0 +1,447 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStatusProvider implements StatusProvider for testing
+type mockStatusProvider struct {
+	status            any
+	statusErr         error
+	scenes            []SceneInfo
+	scenesErr         error
+	audioInputs       []AudioInputInfo
+	audioInputsErr    error
+	screenshotSources []ScreenshotSourceInfo
+	screenshotErr     error
+}
+
+func (m *mockStatusProvider) GetStatus() (any, error) {
+	return m.status, m.statusErr
+}
+
+func (m *mockStatusProvider) GetScenes() ([]SceneInfo, error) {
+	return m.scenes, m.scenesErr
+}
+
+func (m *mockStatusProvider) GetAudioInputs() ([]AudioInputInfo, error) {
+	return m.audioInputs, m.audioInputsErr
+}
+
+func (m *mockStatusProvider) GetScreenshotSources() ([]ScreenshotSourceInfo, error) {
+	return m.screenshotSources, m.screenshotErr
+}
+
+func TestHandleUIStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		provider       *mockStatusProvider
+		wantStatus     int
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:   "returns status dashboard on GET",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				status: map[string]any{
+					"connected":    true,
+					"recording":    false,
+					"streaming":    false,
+					"currentScene": "Main",
+				},
+				scenes: []SceneInfo{
+					{Name: "Main", Index: 0, IsCurrent: true},
+					{Name: "Gaming", Index: 1, IsCurrent: false},
+				},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"agentic-obs", "Status", "Main", "Gaming"},
+		},
+		{
+			name:   "shows error when status fails",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				statusErr: errors.New("connection failed"),
+			},
+			wantStatus:   http.StatusOK, // Still returns 200 with error template
+			wantContains: []string{"Error", "connection failed"},
+		},
+		{
+			name:   "shows empty scenes when scenes fail",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				status: map[string]any{"connected": true},
+				scenesErr: errors.New("scenes error"),
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"Scenes (0)"},
+		},
+		{
+			name:       "rejects POST method",
+			method:     http.MethodPost,
+			provider:   &mockStatusProvider{},
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+
+			req := httptest.NewRequest(tt.method, "/ui/status", nil)
+			rec := httptest.NewRecorder()
+
+			handlers.HandleUIStatus(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			body := rec.Body.String()
+			for _, want := range tt.wantContains {
+				assert.Contains(t, body, want, "response should contain %q", want)
+			}
+			for _, notWant := range tt.wantNotContain {
+				assert.NotContains(t, body, notWant, "response should not contain %q", notWant)
+			}
+		})
+	}
+}
+
+func TestHandleUIScenes(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		provider     *mockStatusProvider
+		wantStatus   int
+		wantContains []string
+	}{
+		{
+			name:   "returns scene grid on GET",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				scenes: []SceneInfo{
+					{Name: "Main", Index: 0, IsCurrent: true},
+					{Name: "BRB", Index: 1, IsCurrent: false},
+					{Name: "Ending", Index: 2, IsCurrent: false},
+				},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"Scene", "Preview", "Main", "BRB", "Ending", "active"},
+		},
+		{
+			name:   "shows empty message when no scenes",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				scenes: []SceneInfo{},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"No scenes available"},
+		},
+		{
+			name:   "shows error when scenes fail",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				scenesErr: errors.New("OBS not connected"),
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"Error", "OBS not connected"},
+		},
+		{
+			name:       "rejects PUT method",
+			method:     http.MethodPut,
+			provider:   &mockStatusProvider{},
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+
+			req := httptest.NewRequest(tt.method, "/ui/scenes", nil)
+			rec := httptest.NewRecorder()
+
+			handlers.HandleUIScenes(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			body := rec.Body.String()
+			for _, want := range tt.wantContains {
+				assert.Contains(t, body, want)
+			}
+		})
+	}
+}
+
+func TestHandleUIAudio(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		provider     *mockStatusProvider
+		wantStatus   int
+		wantContains []string
+	}{
+		{
+			name:   "returns audio mixer on GET",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				audioInputs: []AudioInputInfo{
+					{Name: "Mic/Aux", Volume: 1.0, VolumePercent: 100, VolumeDB: 0, IsMuted: false, InputKind: "wasapi_input_capture"},
+					{Name: "Desktop Audio", Volume: 0.5, VolumePercent: 50, VolumeDB: -6, IsMuted: true, InputKind: "wasapi_output_capture"},
+				},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"Audio", "Mixer", "Mic/Aux", "Desktop Audio", "Unmute"},
+		},
+		{
+			name:   "shows empty message when no inputs",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				audioInputs: []AudioInputInfo{},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"No audio inputs available"},
+		},
+		{
+			name:   "shows error when audio fails",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				audioInputsErr: errors.New("audio subsystem error"),
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"Error", "audio subsystem error"},
+		},
+		{
+			name:       "rejects DELETE method",
+			method:     http.MethodDelete,
+			provider:   &mockStatusProvider{},
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+
+			req := httptest.NewRequest(tt.method, "/ui/audio", nil)
+			rec := httptest.NewRecorder()
+
+			handlers.HandleUIAudio(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			body := rec.Body.String()
+			for _, want := range tt.wantContains {
+				assert.Contains(t, body, want)
+			}
+		})
+	}
+}
+
+func TestHandleUIScreenshots(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		provider     *mockStatusProvider
+		wantStatus   int
+		wantContains []string
+	}{
+		{
+			name:   "returns screenshot gallery on GET",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				screenshotSources: []ScreenshotSourceInfo{
+					{Name: "main-monitor", SourceName: "Display Capture", CadenceMs: 5000, ImageURL: "http://localhost:8765/screenshot/main-monitor", LastCapture: "2025-01-01 12:00:00"},
+					{Name: "game-capture", SourceName: "Game Capture", CadenceMs: 1000, ImageURL: "http://localhost:8765/screenshot/game-capture", LastCapture: "2025-01-01 12:00:01"},
+				},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"Screenshot", "Gallery", "main-monitor", "game-capture", "Display Capture", "Game Capture"},
+		},
+		{
+			name:   "shows empty message when no sources",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				screenshotSources: []ScreenshotSourceInfo{},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"No screenshot sources configured"},
+		},
+		{
+			name:   "shows error when screenshot sources fail",
+			method: http.MethodGet,
+			provider: &mockStatusProvider{
+				screenshotErr: errors.New("database error"),
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"Error", "database error"},
+		},
+		{
+			name:       "rejects PATCH method",
+			method:     http.MethodPatch,
+			provider:   &mockStatusProvider{},
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+
+			req := httptest.NewRequest(tt.method, "/ui/screenshots", nil)
+			rec := httptest.NewRecorder()
+
+			handlers.HandleUIScreenshots(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			body := rec.Body.String()
+			for _, want := range tt.wantContains {
+				assert.Contains(t, body, want)
+			}
+		})
+	}
+}
+
+func TestHandleUIAction(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		body         string
+		wantStatus   int
+		wantResponse map[string]any
+	}{
+		{
+			name:   "acknowledges tool action",
+			method: http.MethodPost,
+			body: `{
+				"type": "tool",
+				"messageId": "msg-123",
+				"payload": {"toolName": "set_current_scene", "params": {"scene_name": "Gaming"}}
+			}`,
+			wantStatus: http.StatusOK,
+			wantResponse: map[string]any{
+				"type":      "ui-message-received",
+				"messageId": "msg-123",
+			},
+		},
+		{
+			name:   "acknowledges intent action",
+			method: http.MethodPost,
+			body: `{
+				"type": "intent",
+				"messageId": "msg-456",
+				"payload": {"intent": "switch_scene", "params": {}}
+			}`,
+			wantStatus: http.StatusOK,
+			wantResponse: map[string]any{
+				"type":      "ui-message-received",
+				"messageId": "msg-456",
+			},
+		},
+		{
+			name:       "rejects GET method",
+			method:     http.MethodGet,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "rejects invalid JSON",
+			method:     http.MethodPost,
+			body:       `{invalid json`,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+
+			var body *strings.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			} else {
+				body = strings.NewReader("")
+			}
+
+			req := httptest.NewRequest(tt.method, "/ui/action", body)
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handlers.HandleUIAction(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantResponse != nil {
+				var got map[string]any
+				err := json.NewDecoder(rec.Body).Decode(&got)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantResponse["type"], got["type"])
+				assert.Equal(t, tt.wantResponse["messageId"], got["messageId"])
+			}
+		})
+	}
+}
+
+func TestUIHandlersContentType(t *testing.T) {
+	provider := &mockStatusProvider{
+		status: map[string]any{"connected": true},
+		scenes: []SceneInfo{{Name: "Test", Index: 0, IsCurrent: true}},
+	}
+	handlers := NewUIHandlers(provider, "http://localhost:8765")
+
+	tests := []struct {
+		name        string
+		handler     func(http.ResponseWriter, *http.Request)
+		wantType    string
+	}{
+		{
+			name:     "status returns HTML",
+			handler:  handlers.HandleUIStatus,
+			wantType: "text/html; charset=utf-8",
+		},
+		{
+			name:     "scenes returns HTML",
+			handler:  handlers.HandleUIScenes,
+			wantType: "text/html; charset=utf-8",
+		},
+		{
+			name:     "audio returns HTML",
+			handler:  handlers.HandleUIAudio,
+			wantType: "text/html; charset=utf-8",
+		},
+		{
+			name:     "screenshots returns HTML",
+			handler:  handlers.HandleUIScreenshots,
+			wantType: "text/html; charset=utf-8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/ui/test", nil)
+			rec := httptest.NewRecorder()
+
+			tt.handler(rec, req)
+
+			assert.Equal(t, tt.wantType, rec.Header().Get("Content-Type"))
+		})
+	}
+}
+
+func TestNewUIHandlers(t *testing.T) {
+	provider := &mockStatusProvider{}
+	handlers := NewUIHandlers(provider, "http://example.com:9000")
+
+	assert.NotNil(t, handlers)
+	assert.Equal(t, "http://example.com:9000", handlers.baseURL)
+	assert.Equal(t, provider, handlers.statusProvider)
+}

--- a/internal/http/ui_handlers_test.go
+++ b/internal/http/ui_handlers_test.go
@@ -139,7 +139,7 @@ func TestHandleUIStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765", 5)
 
 			req := httptest.NewRequest(tt.method, "/ui/status", nil)
 			rec := httptest.NewRecorder()
@@ -208,7 +208,7 @@ func TestHandleUIScenes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765", 5)
 
 			req := httptest.NewRequest(tt.method, "/ui/scenes", nil)
 			rec := httptest.NewRecorder()
@@ -273,7 +273,7 @@ func TestHandleUIAudio(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765", 5)
 
 			req := httptest.NewRequest(tt.method, "/ui/audio", nil)
 			rec := httptest.NewRecorder()
@@ -338,7 +338,7 @@ func TestHandleUIScreenshots(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handlers := NewUIHandlers(tt.provider, "http://localhost:8765")
+			handlers := NewUIHandlers(tt.provider, "http://localhost:8765", 5)
 
 			req := httptest.NewRequest(tt.method, "/ui/screenshots", nil)
 			rec := httptest.NewRecorder()
@@ -406,7 +406,7 @@ func TestHandleUIAction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765", 5)
 
 			var body *strings.Reader
 			if tt.body != "" {
@@ -439,7 +439,7 @@ func TestUIHandlersContentType(t *testing.T) {
 		status: map[string]any{"connected": true},
 		scenes: []SceneInfo{{Name: "Test", Index: 0, IsCurrent: true}},
 	}
-	handlers := NewUIHandlers(provider, "http://localhost:8765")
+	handlers := NewUIHandlers(provider, "http://localhost:8765", 5)
 
 	tests := []struct {
 		name     string
@@ -482,7 +482,7 @@ func TestUIHandlersContentType(t *testing.T) {
 
 func TestNewUIHandlers(t *testing.T) {
 	provider := &mockStatusProvider{}
-	handlers := NewUIHandlers(provider, "http://example.com:9000")
+	handlers := NewUIHandlers(provider, "http://example.com:9000", 5)
 
 	assert.NotNil(t, handlers)
 	assert.Equal(t, "http://example.com:9000", handlers.baseURL)
@@ -490,7 +490,7 @@ func TestNewUIHandlers(t *testing.T) {
 }
 
 func TestSetActionExecutor(t *testing.T) {
-	handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+	handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765", 5)
 	executor := &mockActionExecutor{}
 
 	handlers.SetActionExecutor(executor)
@@ -551,7 +551,7 @@ func TestHandleSceneThumbnail(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765", 5)
 			if tt.executor != nil {
 				handlers.SetActionExecutor(tt.executor)
 			}
@@ -634,7 +634,7 @@ func TestHandleUIActionWithExecutor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765")
+			handlers := NewUIHandlers(&mockStatusProvider{}, "http://localhost:8765", 5)
 			handlers.SetActionExecutor(tt.executor)
 
 			req := httptest.NewRequest(http.MethodPost, "/ui/action", strings.NewReader(tt.body))
@@ -704,7 +704,7 @@ func TestAudioMixerEnhancedTemplate(t *testing.T) {
 			},
 		},
 	}
-	handlers := NewUIHandlers(provider, "http://localhost:8765")
+	handlers := NewUIHandlers(provider, "http://localhost:8765", 5)
 
 	req := httptest.NewRequest(http.MethodGet, "/ui/audio", nil)
 	rec := httptest.NewRecorder()
@@ -753,7 +753,7 @@ func TestAudioMixerWithMutedInput(t *testing.T) {
 			{Name: "Mic", IsMuted: true, VolumePercent: 0, VolumeDB: -100, InputKind: "mic"},
 		},
 	}
-	handlers := NewUIHandlers(provider, "http://localhost:8765")
+	handlers := NewUIHandlers(provider, "http://localhost:8765", 5)
 
 	req := httptest.NewRequest(http.MethodGet, "/ui/audio", nil)
 	rec := httptest.NewRecorder()
@@ -777,7 +777,7 @@ func TestAudioMixerVolumeSliderRange(t *testing.T) {
 			{Name: "Test3", VolumePercent: 100, VolumeDB: 0, InputKind: "test"},
 		},
 	}
-	handlers := NewUIHandlers(provider, "http://localhost:8765")
+	handlers := NewUIHandlers(provider, "http://localhost:8765", 5)
 
 	req := httptest.NewRequest(http.MethodGet, "/ui/audio", nil)
 	rec := httptest.NewRecorder()
@@ -801,7 +801,7 @@ func TestAudioMixerKeyboardHints(t *testing.T) {
 			{Name: "Test", InputKind: "test"},
 		},
 	}
-	handlers := NewUIHandlers(provider, "http://localhost:8765")
+	handlers := NewUIHandlers(provider, "http://localhost:8765", 5)
 
 	req := httptest.NewRequest(http.MethodGet, "/ui/audio", nil)
 	rec := httptest.NewRecorder()

--- a/internal/http/ui_templates.go
+++ b/internal/http/ui_templates.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"embed"
+	"html/template"
+	"sync"
+)
+
+//go:embed templates/*.html templates/*.css
+var templateFiles embed.FS
+
+// templateCache holds parsed templates
+var (
+	templateCache     map[string]*template.Template
+	templateCacheMu   sync.RWMutex
+	templateCacheOnce sync.Once
+)
+
+// initTemplateCache initializes the template cache
+func initTemplateCache() {
+	templateCache = make(map[string]*template.Template)
+}
+
+// getSharedCSS reads the shared CSS file
+func getSharedCSS() string {
+	data, err := templateFiles.ReadFile("templates/shared.css")
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// getTemplate returns a parsed template by name, with caching
+func getTemplate(name string) (*template.Template, error) {
+	templateCacheOnce.Do(initTemplateCache)
+
+	templateCacheMu.RLock()
+	if tmpl, ok := templateCache[name]; ok {
+		templateCacheMu.RUnlock()
+		return tmpl, nil
+	}
+	templateCacheMu.RUnlock()
+
+	// Parse template
+	data, err := templateFiles.ReadFile("templates/" + name + ".html")
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl, err := template.New(name).Parse(string(data))
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the template
+	templateCacheMu.Lock()
+	templateCache[name] = tmpl
+	templateCacheMu.Unlock()
+
+	return tmpl, nil
+}
+
+// Template names
+const (
+	templateStatusDashboard  = "status_dashboard"
+	templateScenePreview     = "scene_preview"
+	templateAudioMixer       = "audio_mixer"
+	templateScreenshotGallery = "screenshot_gallery"
+	templateError            = "error"
+)

--- a/internal/http/ui_templates.go
+++ b/internal/http/ui_templates.go
@@ -62,9 +62,9 @@ func getTemplate(name string) (*template.Template, error) {
 
 // Template names
 const (
-	templateStatusDashboard  = "status_dashboard"
-	templateScenePreview     = "scene_preview"
-	templateAudioMixer       = "audio_mixer"
+	templateStatusDashboard   = "status_dashboard"
+	templateScenePreview      = "scene_preview"
+	templateAudioMixer        = "audio_mixer"
 	templateScreenshotGallery = "screenshot_gallery"
-	templateError            = "error"
+	templateError             = "error"
 )

--- a/internal/mcp/help.go
+++ b/internal/mcp/help.go
@@ -12,8 +12,8 @@ import (
 
 // HelpInput is the input for the help tool
 type HelpInput struct {
-	Topic   string `json:"topic,omitempty" jsonschema:"description=Topic to get help on: 'overview', 'tools', 'resources', 'prompts', 'workflows', 'troubleshooting', or a specific tool name"`
-	Verbose bool   `json:"verbose,omitempty" jsonschema:"description=Include examples and detailed explanations"`
+	Topic   string `json:"topic,omitempty" jsonschema:"Topic to get help on: 'overview', 'tools', 'resources', 'prompts', 'workflows', 'troubleshooting', or a specific tool name"`
+	Verbose bool   `json:"verbose,omitempty" jsonschema:"Include examples and detailed explanations"`
 }
 
 // handleHelp provides comprehensive help on agentic-obs features

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -88,7 +88,134 @@ func (s *Server) registerResourceHandlers() {
 	)
 	resourceCount++
 
+	// Register MCP-UI resources (only if HTTP server is enabled)
+	if s.httpServer != nil {
+		s.registerUIResources(&resourceCount)
+	}
+
 	log.Printf("Resource handlers registered successfully (%d resources)", resourceCount)
+}
+
+// registerUIResources registers UI resources for MCP-UI protocol support
+func (s *Server) registerUIResources(resourceCount *int) {
+	// Status Dashboard UI
+	s.mcpServer.AddResourceTemplate(
+		&mcpsdk.ResourceTemplate{
+			URITemplate: UIStatusDashboardURI,
+			Name:        "OBS Status Dashboard",
+			Description: "Interactive status dashboard with connection info, recording/streaming state, and scene overview",
+			MIMEType:    "text/html",
+		},
+		s.handleUIStatusResource,
+	)
+	*resourceCount++
+
+	// Scene Preview UI
+	s.mcpServer.AddResourceTemplate(
+		&mcpsdk.ResourceTemplate{
+			URITemplate: UIScenePreviewURI,
+			Name:        "Scene Preview",
+			Description: "Visual scene grid with thumbnails for interactive scene switching",
+			MIMEType:    "text/html",
+		},
+		s.handleUIScenePreviewResource,
+	)
+	*resourceCount++
+
+	// Audio Mixer UI
+	s.mcpServer.AddResourceTemplate(
+		&mcpsdk.ResourceTemplate{
+			URITemplate: UIAudioMixerURI,
+			Name:        "Audio Mixer",
+			Description: "Audio input controls with volume sliders and mute toggles",
+			MIMEType:    "text/html",
+		},
+		s.handleUIAudioMixerResource,
+	)
+	*resourceCount++
+
+	// Screenshot Gallery UI
+	s.mcpServer.AddResourceTemplate(
+		&mcpsdk.ResourceTemplate{
+			URITemplate: UIScreenshotGalleryURI,
+			Name:        "Screenshot Gallery",
+			Description: "Live screenshot gallery from configured screenshot sources",
+			MIMEType:    "text/html",
+		},
+		s.handleUIScreenshotGalleryResource,
+	)
+	*resourceCount++
+
+	log.Println("MCP-UI resources registered (4 UI resources)")
+}
+
+// handleUIStatusResource returns the status dashboard UI
+func (s *Server) handleUIStatusResource(ctx context.Context, request *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	log.Printf("Handling UI resource read for: %s", request.Params.URI)
+
+	// Return URL reference to the HTTP-served UI
+	urlContent := fmt.Sprintf(`{"url": "%s/ui/status", "type": "url"}`, s.httpServer.GetAddr())
+
+	return &mcpsdk.ReadResourceResult{
+		Contents: []*mcpsdk.ResourceContents{
+			{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     urlContent,
+			},
+		},
+	}, nil
+}
+
+// handleUIScenePreviewResource returns the scene preview UI
+func (s *Server) handleUIScenePreviewResource(ctx context.Context, request *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	log.Printf("Handling UI resource read for: %s", request.Params.URI)
+
+	urlContent := fmt.Sprintf(`{"url": "%s/ui/scenes", "type": "url"}`, s.httpServer.GetAddr())
+
+	return &mcpsdk.ReadResourceResult{
+		Contents: []*mcpsdk.ResourceContents{
+			{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     urlContent,
+			},
+		},
+	}, nil
+}
+
+// handleUIAudioMixerResource returns the audio mixer UI
+func (s *Server) handleUIAudioMixerResource(ctx context.Context, request *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	log.Printf("Handling UI resource read for: %s", request.Params.URI)
+
+	urlContent := fmt.Sprintf(`{"url": "%s/ui/audio", "type": "url"}`, s.httpServer.GetAddr())
+
+	return &mcpsdk.ReadResourceResult{
+		Contents: []*mcpsdk.ResourceContents{
+			{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     urlContent,
+			},
+		},
+	}, nil
+}
+
+// handleUIScreenshotGalleryResource returns the screenshot gallery UI
+func (s *Server) handleUIScreenshotGalleryResource(ctx context.Context, request *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	log.Printf("Handling UI resource read for: %s", request.Params.URI)
+
+	urlContent := fmt.Sprintf(`{"url": "%s/ui/screenshots", "type": "url"}`, s.httpServer.GetAddr())
+
+	return &mcpsdk.ReadResourceResult{
+		Contents: []*mcpsdk.ResourceContents{
+			{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     urlContent,
+			},
+		},
+	}, nil
 }
 
 // handleResourceRead returns detailed information about a specific scene

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -103,6 +103,8 @@ func NewServer(config ServerConfig) (*Server, error) {
 			httpCfg.Port = config.HTTPPort
 		}
 		s.httpServer = agenthttp.NewServer(db, httpCfg)
+		// Set MCP server as status provider for UI endpoints
+		s.httpServer.SetStatusProvider(s)
 	}
 
 	// Initialize screenshot manager (works without HTTP server for MCP resource access)

--- a/internal/mcp/status_provider.go
+++ b/internal/mcp/status_provider.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+
+	agenthttp "github.com/ironystock/agentic-obs/internal/http"
+)
+
+// Ensure Server implements StatusProvider
+var _ agenthttp.StatusProvider = (*Server)(nil)
+
+// GetStatus returns the current OBS status.
+func (s *Server) GetStatus() (any, error) {
+	if !s.obsClient.IsConnected() {
+		return map[string]any{
+			"connected":    false,
+			"recording":    false,
+			"streaming":    false,
+			"currentScene": "",
+		}, nil
+	}
+
+	status, err := s.obsClient.GetOBSStatus()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"connected":        true,
+		"recording":        status.Recording,
+		"streaming":        status.Streaming,
+		"currentScene":     status.CurrentScene,
+		"obsVersion":       status.Version,
+		"websocketVersion": status.WebSocketVersion,
+	}, nil
+}
+
+// GetScenes returns a list of scenes for UI display.
+func (s *Server) GetScenes() ([]agenthttp.SceneInfo, error) {
+	if !s.obsClient.IsConnected() {
+		return []agenthttp.SceneInfo{}, nil
+	}
+
+	sceneNames, currentScene, err := s.obsClient.GetSceneList()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]agenthttp.SceneInfo, len(sceneNames))
+	for i, name := range sceneNames {
+		result[i] = agenthttp.SceneInfo{
+			Name:      name,
+			Index:     i,
+			IsCurrent: name == currentScene,
+		}
+	}
+
+	return result, nil
+}
+
+// GetAudioInputs returns a list of audio inputs with their current state.
+func (s *Server) GetAudioInputs() ([]agenthttp.AudioInputInfo, error) {
+	if !s.obsClient.IsConnected() {
+		return []agenthttp.AudioInputInfo{}, nil
+	}
+
+	inputs, err := s.obsClient.ListSources()
+	if err != nil {
+		return nil, err
+	}
+
+	result := []agenthttp.AudioInputInfo{}
+	for _, input := range inputs {
+		// Only include audio inputs (those that support volume control)
+		volumeMul, volumeDB, err := s.obsClient.GetInputVolume(input.InputName)
+		if err != nil {
+			continue // Skip non-audio inputs
+		}
+
+		muted, _ := s.obsClient.GetInputMute(input.InputName)
+
+		result = append(result, agenthttp.AudioInputInfo{
+			Name:          input.InputName,
+			Volume:        volumeMul,
+			VolumePercent: volumeMul * 100,
+			VolumeDB:      volumeDB,
+			IsMuted:       muted,
+			InputKind:     input.InputKind,
+		})
+	}
+
+	return result, nil
+}
+
+// GetScreenshotSources returns a list of screenshot sources for UI display.
+func (s *Server) GetScreenshotSources() ([]agenthttp.ScreenshotSourceInfo, error) {
+	ctx := context.Background()
+
+	sources, err := s.storage.ListScreenshotSources(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL := ""
+	if s.httpServer != nil {
+		baseURL = s.httpServer.GetAddr()
+	}
+
+	result := make([]agenthttp.ScreenshotSourceInfo, len(sources))
+	for i, source := range sources {
+		imageURL := ""
+		if baseURL != "" {
+			imageURL = baseURL + "/screenshot/" + source.Name
+		}
+
+		lastCapture := "Never"
+		screenshot, err := s.storage.GetLatestScreenshot(ctx, source.ID)
+		if err == nil && screenshot != nil {
+			lastCapture = screenshot.CapturedAt.Format("2006-01-02 15:04:05")
+		}
+
+		result[i] = agenthttp.ScreenshotSourceInfo{
+			Name:        source.Name,
+			SourceName:  source.SourceName,
+			CadenceMs:   source.CadenceMs,
+			ImageURL:    imageURL,
+			LastCapture: lastCapture,
+		}
+	}
+
+	return result, nil
+}

--- a/internal/mcp/status_provider.go
+++ b/internal/mcp/status_provider.go
@@ -109,8 +109,11 @@ func (s *Server) GetAudioInputs() ([]agenthttp.AudioInputInfo, error) {
 		muted, _ := s.obsClient.GetInputMute(input.InputName)
 
 		// Convert dB to slider percentage (0-100) using logarithmic curve
+		// The constant 30 creates a perceptual loudness curve matching pro audio consoles:
+		// - Based on Stevens' power law for human loudness perception
+		// - 10dB change ≈ "twice as loud" perception, so 50% slider ≈ -10dB
 		// Formula: sliderPercent = 10^(dB/30) * 100
-		// This gives: 0dB=100%, -10dB≈46%, -20dB≈22%, -30dB=10%, -60dB≈1%
+		// Gives: 0dB=100%, -10dB≈46%, -20dB≈22%, -30dB=10%, -60dB≈1%
 		volumePercent := 0.0
 		if volumeMul > 0 && volumeDB > -60 {
 			volumePercent = math.Pow(10, volumeDB/30) * 100

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -48,155 +48,155 @@ type SetVolumeInput struct {
 
 // ListPresetsInput is the input for listing scene presets
 type ListPresetsInput struct {
-	SceneName string `json:"scene_name,omitempty" jsonschema:"description=Optional scene name to filter presets by"`
+	SceneName string `json:"scene_name,omitempty" jsonschema:"Optional scene name to filter presets by"`
 }
 
 // PresetNameInput is the input for preset operations by name
 type PresetNameInput struct {
-	PresetName string `json:"preset_name" jsonschema:"required,description=Name of the preset to operate on"`
+	PresetName string `json:"preset_name" jsonschema:"Name of the preset to operate on"`
 }
 
 // RenamePresetInput is the input for renaming a preset
 type RenamePresetInput struct {
-	OldName string `json:"old_name" jsonschema:"required,description=Current name of the preset to rename"`
-	NewName string `json:"new_name" jsonschema:"required,description=New name for the preset"`
+	OldName string `json:"old_name" jsonschema:"Current name of the preset to rename"`
+	NewName string `json:"new_name" jsonschema:"New name for the preset"`
 }
 
 // SavePresetInput is the input for saving a scene preset
 type SavePresetInput struct {
-	PresetName string `json:"preset_name" jsonschema:"required,description=Name to give the new preset"`
-	SceneName  string `json:"scene_name" jsonschema:"required,description=Name of the OBS scene to capture state from"`
+	PresetName string `json:"preset_name" jsonschema:"Name to give the new preset"`
+	SceneName  string `json:"scene_name" jsonschema:"Name of the OBS scene to capture state from"`
 }
 
 // CreateScreenshotSourceInput is the input for creating a screenshot source
 type CreateScreenshotSourceInput struct {
-	Name        string `json:"name" jsonschema:"required,description=Unique name for this screenshot source"`
-	SourceName  string `json:"source_name" jsonschema:"required,description=OBS scene or source name to capture"`
-	CadenceMs   int    `json:"cadence_ms,omitempty" jsonschema:"description=Capture interval in milliseconds (default: 5000)"`
-	ImageFormat string `json:"image_format,omitempty" jsonschema:"description=Image format: png or jpg (default: png)"`
-	ImageWidth  int    `json:"image_width,omitempty" jsonschema:"description=Optional resize width (0 = original)"`
-	ImageHeight int    `json:"image_height,omitempty" jsonschema:"description=Optional resize height (0 = original)"`
-	Quality     int    `json:"quality,omitempty" jsonschema:"description=Compression quality 0-100 (default: 80)"`
+	Name        string `json:"name" jsonschema:"Unique name for this screenshot source"`
+	SourceName  string `json:"source_name" jsonschema:"OBS scene or source name to capture"`
+	CadenceMs   int    `json:"cadence_ms,omitempty" jsonschema:"Capture interval in milliseconds (default: 5000)"`
+	ImageFormat string `json:"image_format,omitempty" jsonschema:"Image format: png or jpg (default: png)"`
+	ImageWidth  int    `json:"image_width,omitempty" jsonschema:"Optional resize width (0 = original)"`
+	ImageHeight int    `json:"image_height,omitempty" jsonschema:"Optional resize height (0 = original)"`
+	Quality     int    `json:"quality,omitempty" jsonschema:"Compression quality 0-100 (default: 80)"`
 }
 
 // ScreenshotSourceNameInput is the input for screenshot source operations by name
 type ScreenshotSourceNameInput struct {
-	Name string `json:"name" jsonschema:"required,description=Name of the screenshot source"`
+	Name string `json:"name" jsonschema:"Name of the screenshot source"`
 }
 
 // ConfigureScreenshotCadenceInput is the input for updating screenshot cadence
 type ConfigureScreenshotCadenceInput struct {
-	Name      string `json:"name" jsonschema:"required,description=Name of the screenshot source"`
-	CadenceMs int    `json:"cadence_ms" jsonschema:"required,description=New capture interval in milliseconds"`
+	Name      string `json:"name" jsonschema:"Name of the screenshot source"`
+	CadenceMs int    `json:"cadence_ms" jsonschema:"New capture interval in milliseconds"`
 }
 
 // Design tool input types
 
 // CreateTextSourceInput is the input for creating a text source
 type CreateTextSourceInput struct {
-	SceneName  string `json:"scene_name" jsonschema:"required,description=Name of the scene to add the source to"`
-	SourceName string `json:"source_name" jsonschema:"required,description=Name for the new text source"`
-	Text       string `json:"text" jsonschema:"required,description=Text content to display"`
-	FontName   string `json:"font_name,omitempty" jsonschema:"description=Font face name (default: Arial)"`
-	FontSize   int    `json:"font_size,omitempty" jsonschema:"description=Font size in points (default: 36)"`
-	Color      int64  `json:"color,omitempty" jsonschema:"description=Text color as ABGR integer (default: white)"`
+	SceneName  string `json:"scene_name" jsonschema:"Name of the scene to add the source to"`
+	SourceName string `json:"source_name" jsonschema:"Name for the new text source"`
+	Text       string `json:"text" jsonschema:"Text content to display"`
+	FontName   string `json:"font_name,omitempty" jsonschema:"Font face name (default: Arial)"`
+	FontSize   int    `json:"font_size,omitempty" jsonschema:"Font size in points (default: 36)"`
+	Color      int64  `json:"color,omitempty" jsonschema:"Text color as ABGR integer (default: white)"`
 }
 
 // CreateImageSourceInput is the input for creating an image source
 type CreateImageSourceInput struct {
-	SceneName  string `json:"scene_name" jsonschema:"required,description=Name of the scene to add the source to"`
-	SourceName string `json:"source_name" jsonschema:"required,description=Name for the new image source"`
-	FilePath   string `json:"file_path" jsonschema:"required,description=Path to the image file"`
+	SceneName  string `json:"scene_name" jsonschema:"Name of the scene to add the source to"`
+	SourceName string `json:"source_name" jsonschema:"Name for the new image source"`
+	FilePath   string `json:"file_path" jsonschema:"Path to the image file"`
 }
 
 // CreateColorSourceInput is the input for creating a color source
 type CreateColorSourceInput struct {
-	SceneName  string `json:"scene_name" jsonschema:"required,description=Name of the scene to add the source to"`
-	SourceName string `json:"source_name" jsonschema:"required,description=Name for the new color source"`
-	Color      int64  `json:"color" jsonschema:"required,description=Color as ABGR integer (e.g., 0xFF0000FF for red)"`
-	Width      int    `json:"width,omitempty" jsonschema:"description=Width in pixels (default: 1920)"`
-	Height     int    `json:"height,omitempty" jsonschema:"description=Height in pixels (default: 1080)"`
+	SceneName  string `json:"scene_name" jsonschema:"Name of the scene to add the source to"`
+	SourceName string `json:"source_name" jsonschema:"Name for the new color source"`
+	Color      int64  `json:"color" jsonschema:"Color as ABGR integer (e.g., 0xFF0000FF for red)"`
+	Width      int    `json:"width,omitempty" jsonschema:"Width in pixels (default: 1920)"`
+	Height     int    `json:"height,omitempty" jsonschema:"Height in pixels (default: 1080)"`
 }
 
 // CreateBrowserSourceInput is the input for creating a browser source
 type CreateBrowserSourceInput struct {
-	SceneName  string `json:"scene_name" jsonschema:"required,description=Name of the scene to add the source to"`
-	SourceName string `json:"source_name" jsonschema:"required,description=Name for the new browser source"`
-	URL        string `json:"url" jsonschema:"required,description=URL to load in the browser source"`
-	Width      int    `json:"width,omitempty" jsonschema:"description=Browser width in pixels (default: 800)"`
-	Height     int    `json:"height,omitempty" jsonschema:"description=Browser height in pixels (default: 600)"`
-	FPS        int    `json:"fps,omitempty" jsonschema:"description=Frame rate (default: 30)"`
+	SceneName  string `json:"scene_name" jsonschema:"Name of the scene to add the source to"`
+	SourceName string `json:"source_name" jsonschema:"Name for the new browser source"`
+	URL        string `json:"url" jsonschema:"URL to load in the browser source"`
+	Width      int    `json:"width,omitempty" jsonschema:"Browser width in pixels (default: 800)"`
+	Height     int    `json:"height,omitempty" jsonschema:"Browser height in pixels (default: 600)"`
+	FPS        int    `json:"fps,omitempty" jsonschema:"Frame rate (default: 30)"`
 }
 
 // CreateMediaSourceInput is the input for creating a media/video source
 type CreateMediaSourceInput struct {
-	SceneName  string `json:"scene_name" jsonschema:"required,description=Name of the scene to add the source to"`
-	SourceName string `json:"source_name" jsonschema:"required,description=Name for the new media source"`
-	FilePath   string `json:"file_path" jsonschema:"required,description=Path to the media file"`
-	Loop       bool   `json:"loop,omitempty" jsonschema:"description=Whether to loop the media (default: false)"`
+	SceneName  string `json:"scene_name" jsonschema:"Name of the scene to add the source to"`
+	SourceName string `json:"source_name" jsonschema:"Name for the new media source"`
+	FilePath   string `json:"file_path" jsonschema:"Path to the media file"`
+	Loop       bool   `json:"loop,omitempty" jsonschema:"Whether to loop the media (default: false)"`
 }
 
 // SetSourceTransformInput is the input for setting source transform properties
 type SetSourceTransformInput struct {
-	SceneName   string   `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID int      `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source"`
-	X           *float64 `json:"x,omitempty" jsonschema:"description=X position in pixels"`
-	Y           *float64 `json:"y,omitempty" jsonschema:"description=Y position in pixels"`
-	ScaleX      *float64 `json:"scale_x,omitempty" jsonschema:"description=X scale factor (1.0 = 100%)"`
-	ScaleY      *float64 `json:"scale_y,omitempty" jsonschema:"description=Y scale factor (1.0 = 100%)"`
-	Rotation    *float64 `json:"rotation,omitempty" jsonschema:"description=Rotation in degrees"`
+	SceneName   string   `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID int      `json:"scene_item_id" jsonschema:"Scene item ID of the source"`
+	X           *float64 `json:"x,omitempty" jsonschema:"X position in pixels"`
+	Y           *float64 `json:"y,omitempty" jsonschema:"Y position in pixels"`
+	ScaleX      *float64 `json:"scale_x,omitempty" jsonschema:"X scale factor (1.0 = 100%)"`
+	ScaleY      *float64 `json:"scale_y,omitempty" jsonschema:"Y scale factor (1.0 = 100%)"`
+	Rotation    *float64 `json:"rotation,omitempty" jsonschema:"Rotation in degrees"`
 }
 
 // GetSourceTransformInput is the input for getting source transform properties
 type GetSourceTransformInput struct {
-	SceneName   string `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID int    `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source"`
+	SceneName   string `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID int    `json:"scene_item_id" jsonschema:"Scene item ID of the source"`
 }
 
 // SetSourceCropInput is the input for setting source crop
 type SetSourceCropInput struct {
-	SceneName   string `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID int    `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source"`
-	CropTop     int    `json:"crop_top,omitempty" jsonschema:"description=Pixels to crop from top"`
-	CropBottom  int    `json:"crop_bottom,omitempty" jsonschema:"description=Pixels to crop from bottom"`
-	CropLeft    int    `json:"crop_left,omitempty" jsonschema:"description=Pixels to crop from left"`
-	CropRight   int    `json:"crop_right,omitempty" jsonschema:"description=Pixels to crop from right"`
+	SceneName   string `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID int    `json:"scene_item_id" jsonschema:"Scene item ID of the source"`
+	CropTop     int    `json:"crop_top,omitempty" jsonschema:"Pixels to crop from top"`
+	CropBottom  int    `json:"crop_bottom,omitempty" jsonschema:"Pixels to crop from bottom"`
+	CropLeft    int    `json:"crop_left,omitempty" jsonschema:"Pixels to crop from left"`
+	CropRight   int    `json:"crop_right,omitempty" jsonschema:"Pixels to crop from right"`
 }
 
 // SetSourceBoundsInput is the input for setting source bounds
 type SetSourceBoundsInput struct {
-	SceneName    string  `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID  int     `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source"`
-	BoundsType   string  `json:"bounds_type" jsonschema:"required,description=Bounds type: OBS_BOUNDS_NONE, OBS_BOUNDS_STRETCH, OBS_BOUNDS_SCALE_INNER, OBS_BOUNDS_SCALE_OUTER, OBS_BOUNDS_SCALE_TO_WIDTH, OBS_BOUNDS_SCALE_TO_HEIGHT, OBS_BOUNDS_MAX_ONLY"`
-	BoundsWidth  float64 `json:"bounds_width,omitempty" jsonschema:"description=Bounds width in pixels"`
-	BoundsHeight float64 `json:"bounds_height,omitempty" jsonschema:"description=Bounds height in pixels"`
+	SceneName    string  `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID  int     `json:"scene_item_id" jsonschema:"Scene item ID of the source"`
+	BoundsType   string  `json:"bounds_type" jsonschema:"Bounds type: OBS_BOUNDS_NONE, OBS_BOUNDS_STRETCH, OBS_BOUNDS_SCALE_INNER, OBS_BOUNDS_SCALE_OUTER, OBS_BOUNDS_SCALE_TO_WIDTH, OBS_BOUNDS_SCALE_TO_HEIGHT, OBS_BOUNDS_MAX_ONLY"`
+	BoundsWidth  float64 `json:"bounds_width,omitempty" jsonschema:"Bounds width in pixels"`
+	BoundsHeight float64 `json:"bounds_height,omitempty" jsonschema:"Bounds height in pixels"`
 }
 
 // SetSourceOrderInput is the input for setting source z-order
 type SetSourceOrderInput struct {
-	SceneName   string `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID int    `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source"`
-	Index       int    `json:"index" jsonschema:"required,description=New index position (0 = bottom, higher = front)"`
+	SceneName   string `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID int    `json:"scene_item_id" jsonschema:"Scene item ID of the source"`
+	Index       int    `json:"index" jsonschema:"New index position (0 = bottom, higher = front)"`
 }
 
 // SetSourceLockedInput is the input for locking/unlocking a source
 type SetSourceLockedInput struct {
-	SceneName   string `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID int    `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source"`
-	Locked      bool   `json:"locked" jsonschema:"required,description=Whether the source should be locked"`
+	SceneName   string `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID int    `json:"scene_item_id" jsonschema:"Scene item ID of the source"`
+	Locked      bool   `json:"locked" jsonschema:"Whether the source should be locked"`
 }
 
 // DuplicateSourceInput is the input for duplicating a source
 type DuplicateSourceInput struct {
-	SceneName     string `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID   int    `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source to duplicate"`
-	DestSceneName string `json:"dest_scene_name,omitempty" jsonschema:"description=Destination scene name (default: same scene)"`
+	SceneName     string `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID   int    `json:"scene_item_id" jsonschema:"Scene item ID of the source to duplicate"`
+	DestSceneName string `json:"dest_scene_name,omitempty" jsonschema:"Destination scene name (default: same scene)"`
 }
 
 // RemoveSourceInput is the input for removing a source from a scene
 type RemoveSourceInput struct {
-	SceneName   string `json:"scene_name" jsonschema:"required,description=Name of the scene containing the source"`
-	SceneItemID int    `json:"scene_item_id" jsonschema:"required,description=Scene item ID of the source to remove"`
+	SceneName   string `json:"scene_name" jsonschema:"Name of the scene containing the source"`
+	SceneItemID int    `json:"scene_item_id" jsonschema:"Scene item ID of the source to remove"`
 }
 
 // registerToolHandlers registers MCP tool handlers based on enabled tool groups

--- a/internal/mcp/ui_resources.go
+++ b/internal/mcp/ui_resources.go
@@ -1,0 +1,130 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/ironystock/agentic-obs/pkg/mcpui"
+)
+
+// UI resource URI patterns
+const (
+	UIStatusDashboardURI   = "ui://status/dashboard"
+	UIScenePreviewURI      = "ui://scene/preview"
+	UIAudioMixerURI        = "ui://audio/mixer"
+	UIScreenshotGalleryURI = "ui://screenshot/gallery"
+)
+
+// UIResourceRegistry defines available UI resources for MCP clients.
+type UIResourceRegistry struct {
+	httpBaseURL string
+}
+
+// NewUIResourceRegistry creates a new registry with the HTTP server base URL.
+func NewUIResourceRegistry(httpBaseURL string) *UIResourceRegistry {
+	return &UIResourceRegistry{
+		httpBaseURL: httpBaseURL,
+	}
+}
+
+// ListUIResources returns all available UI resources.
+func (r *UIResourceRegistry) ListUIResources() []*mcpui.UIResource {
+	return []*mcpui.UIResource{
+		{
+			URI:         UIStatusDashboardURI,
+			Name:        "status-dashboard",
+			Title:       "OBS Status Dashboard",
+			Description: "Real-time OBS connection status, recording/streaming state, and scene overview",
+			MIMEType:    mcpui.MIMETypeHTML,
+		},
+		{
+			URI:         UIScenePreviewURI,
+			Name:        "scene-preview",
+			Title:       "Scene Preview",
+			Description: "Visual scene grid with thumbnails for quick scene switching",
+			MIMEType:    mcpui.MIMETypeHTML,
+		},
+		{
+			URI:         UIAudioMixerURI,
+			Name:        "audio-mixer",
+			Title:       "Audio Mixer",
+			Description: "Audio input controls with volume sliders and mute toggles",
+			MIMEType:    mcpui.MIMETypeHTML,
+		},
+		{
+			URI:         UIScreenshotGalleryURI,
+			Name:        "screenshot-gallery",
+			Title:       "Screenshot Gallery",
+			Description: "Live screenshot gallery from configured screenshot sources",
+			MIMEType:    mcpui.MIMETypeHTML,
+		},
+	}
+}
+
+// GetUIResourceTemplate returns a template for dynamic UI resources.
+func (r *UIResourceRegistry) GetUIResourceTemplate(uri string) *mcpui.UIResourceTemplate {
+	switch uri {
+	case UIStatusDashboardURI:
+		return &mcpui.UIResourceTemplate{
+			URITemplate: UIStatusDashboardURI,
+			Name:        "status-dashboard",
+			Title:       "OBS Status Dashboard",
+			Description: "Real-time OBS status information",
+			MIMEType:    mcpui.MIMETypeHTML,
+		}
+	default:
+		return nil
+	}
+}
+
+// BuildStatusDashboardURL returns the HTTP URL for the status dashboard UI.
+func (r *UIResourceRegistry) BuildStatusDashboardURL() string {
+	return fmt.Sprintf("%s/ui/status", r.httpBaseURL)
+}
+
+// BuildScenePreviewURL returns the HTTP URL for the scene preview UI.
+func (r *UIResourceRegistry) BuildScenePreviewURL() string {
+	return fmt.Sprintf("%s/ui/scenes", r.httpBaseURL)
+}
+
+// BuildAudioMixerURL returns the HTTP URL for the audio mixer UI.
+func (r *UIResourceRegistry) BuildAudioMixerURL() string {
+	return fmt.Sprintf("%s/ui/audio", r.httpBaseURL)
+}
+
+// BuildScreenshotGalleryURL returns the HTTP URL for the screenshot gallery UI.
+func (r *UIResourceRegistry) BuildScreenshotGalleryURL() string {
+	return fmt.Sprintf("%s/ui/screenshots", r.httpBaseURL)
+}
+
+// NewStatusDashboardResource creates a UIResourceContents for the status dashboard.
+// This returns an URLContent pointing to the HTTP-served UI.
+func (r *UIResourceRegistry) NewStatusDashboardResource() (*mcpui.UIResourceContents, error) {
+	content := &mcpui.URLContent{
+		URL: r.BuildStatusDashboardURL(),
+	}
+	return mcpui.NewUIResourceContents(UIStatusDashboardURI, content)
+}
+
+// NewScenePreviewResource creates a UIResourceContents for the scene preview.
+func (r *UIResourceRegistry) NewScenePreviewResource() (*mcpui.UIResourceContents, error) {
+	content := &mcpui.URLContent{
+		URL: r.BuildScenePreviewURL(),
+	}
+	return mcpui.NewUIResourceContents(UIScenePreviewURI, content)
+}
+
+// NewAudioMixerResource creates a UIResourceContents for the audio mixer.
+func (r *UIResourceRegistry) NewAudioMixerResource() (*mcpui.UIResourceContents, error) {
+	content := &mcpui.URLContent{
+		URL: r.BuildAudioMixerURL(),
+	}
+	return mcpui.NewUIResourceContents(UIAudioMixerURI, content)
+}
+
+// NewScreenshotGalleryResource creates a UIResourceContents for the screenshot gallery.
+func (r *UIResourceRegistry) NewScreenshotGalleryResource() (*mcpui.UIResourceContents, error) {
+	content := &mcpui.URLContent{
+		URL: r.BuildScreenshotGalleryURL(),
+	}
+	return mcpui.NewUIResourceContents(UIScreenshotGalleryURI, content)
+}

--- a/internal/mcp/ui_resources_test.go
+++ b/internal/mcp/ui_resources_test.go
@@ -1,0 +1,162 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/ironystock/agentic-obs/pkg/mcpui"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewUIResourceRegistry(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:8765")
+
+	assert.NotNil(t, registry)
+	assert.Equal(t, "http://localhost:8765", registry.httpBaseURL)
+}
+
+func TestUIResourceRegistry_ListUIResources(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:8765")
+
+	resources := registry.ListUIResources()
+
+	assert.Len(t, resources, 4)
+
+	// Verify all expected resources are present
+	uriMap := make(map[string]*mcpui.UIResource)
+	for _, r := range resources {
+		uriMap[r.URI] = r
+	}
+
+	// Status dashboard
+	assert.Contains(t, uriMap, UIStatusDashboardURI)
+	assert.Equal(t, "status-dashboard", uriMap[UIStatusDashboardURI].Name)
+	assert.Equal(t, mcpui.MIMETypeHTML, uriMap[UIStatusDashboardURI].MIMEType)
+
+	// Scene preview
+	assert.Contains(t, uriMap, UIScenePreviewURI)
+	assert.Equal(t, "scene-preview", uriMap[UIScenePreviewURI].Name)
+
+	// Audio mixer
+	assert.Contains(t, uriMap, UIAudioMixerURI)
+	assert.Equal(t, "audio-mixer", uriMap[UIAudioMixerURI].Name)
+
+	// Screenshot gallery
+	assert.Contains(t, uriMap, UIScreenshotGalleryURI)
+	assert.Equal(t, "screenshot-gallery", uriMap[UIScreenshotGalleryURI].Name)
+}
+
+func TestUIResourceRegistry_BuildURLs(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:9000")
+
+	tests := []struct {
+		name     string
+		method   func() string
+		expected string
+	}{
+		{
+			name:     "status dashboard URL",
+			method:   registry.BuildStatusDashboardURL,
+			expected: "http://localhost:9000/ui/status",
+		},
+		{
+			name:     "scene preview URL",
+			method:   registry.BuildScenePreviewURL,
+			expected: "http://localhost:9000/ui/scenes",
+		},
+		{
+			name:     "audio mixer URL",
+			method:   registry.BuildAudioMixerURL,
+			expected: "http://localhost:9000/ui/audio",
+		},
+		{
+			name:     "screenshot gallery URL",
+			method:   registry.BuildScreenshotGalleryURL,
+			expected: "http://localhost:9000/ui/screenshots",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.method())
+		})
+	}
+}
+
+func TestUIResourceRegistry_NewStatusDashboardResource(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:8765")
+
+	resource, err := registry.NewStatusDashboardResource()
+
+	require.NoError(t, err)
+	assert.Equal(t, UIStatusDashboardURI, resource.URI)
+	assert.Equal(t, mcpui.MIMETypeURLList, resource.MIMEType)
+	assert.Equal(t, "http://localhost:8765/ui/status", resource.Text)
+}
+
+func TestUIResourceRegistry_NewScenePreviewResource(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:8765")
+
+	resource, err := registry.NewScenePreviewResource()
+
+	require.NoError(t, err)
+	assert.Equal(t, UIScenePreviewURI, resource.URI)
+	assert.Equal(t, mcpui.MIMETypeURLList, resource.MIMEType)
+	assert.Equal(t, "http://localhost:8765/ui/scenes", resource.Text)
+}
+
+func TestUIResourceRegistry_NewAudioMixerResource(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:8765")
+
+	resource, err := registry.NewAudioMixerResource()
+
+	require.NoError(t, err)
+	assert.Equal(t, UIAudioMixerURI, resource.URI)
+	assert.Equal(t, mcpui.MIMETypeURLList, resource.MIMEType)
+	assert.Equal(t, "http://localhost:8765/ui/audio", resource.Text)
+}
+
+func TestUIResourceRegistry_NewScreenshotGalleryResource(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:8765")
+
+	resource, err := registry.NewScreenshotGalleryResource()
+
+	require.NoError(t, err)
+	assert.Equal(t, UIScreenshotGalleryURI, resource.URI)
+	assert.Equal(t, mcpui.MIMETypeURLList, resource.MIMEType)
+	assert.Equal(t, "http://localhost:8765/ui/screenshots", resource.Text)
+}
+
+func TestUIResourceRegistry_GetUIResourceTemplate(t *testing.T) {
+	registry := NewUIResourceRegistry("http://localhost:8765")
+
+	t.Run("returns template for status dashboard", func(t *testing.T) {
+		template := registry.GetUIResourceTemplate(UIStatusDashboardURI)
+
+		require.NotNil(t, template)
+		assert.Equal(t, UIStatusDashboardURI, template.URITemplate)
+		assert.Equal(t, "status-dashboard", template.Name)
+		assert.Equal(t, mcpui.MIMETypeHTML, template.MIMEType)
+	})
+
+	t.Run("returns nil for unknown URI", func(t *testing.T) {
+		template := registry.GetUIResourceTemplate("ui://unknown/resource")
+
+		assert.Nil(t, template)
+	})
+}
+
+func TestUIResourceURIConstants(t *testing.T) {
+	// Verify URI constants follow the ui:// scheme
+	assert.True(t, len(UIStatusDashboardURI) > 5)
+	assert.Equal(t, "ui://", UIStatusDashboardURI[:5])
+
+	assert.True(t, len(UIScenePreviewURI) > 5)
+	assert.Equal(t, "ui://", UIScenePreviewURI[:5])
+
+	assert.True(t, len(UIAudioMixerURI) > 5)
+	assert.Equal(t, "ui://", UIAudioMixerURI[:5])
+
+	assert.True(t, len(UIScreenshotGalleryURI) > 5)
+	assert.Equal(t, "ui://", UIScreenshotGalleryURI[:5])
+}

--- a/internal/obs/commands.go
+++ b/internal/obs/commands.go
@@ -437,6 +437,7 @@ func (c *Client) SetInputVolume(inputName string, volumeDb *float64, volumeMul *
 }
 
 // GetInputVolume retrieves the volume level of an audio input.
+// Returns (volumeMultiplier, volumeDb, error).
 func (c *Client) GetInputVolume(inputName string) (float64, float64, error) {
 	client, err := c.getClient()
 	if err != nil {
@@ -451,7 +452,7 @@ func (c *Client) GetInputVolume(inputName string) (float64, float64, error) {
 		return 0, 0, fmt.Errorf("failed to get volume for input '%s': %w. Input may not exist", inputName, err)
 	}
 
-	return resp.InputVolumeDb, resp.InputVolumeMul, nil
+	return resp.InputVolumeMul, resp.InputVolumeDb, nil
 }
 
 // GetOBSStatus retrieves overall OBS status information.

--- a/main.go
+++ b/main.go
@@ -72,15 +72,16 @@ func main() {
 	// Step 3: Create MCP server (includes storage and OBS client initialization)
 	log.Println("[3/5] Initializing MCP server...")
 	serverConfig := mcp.ServerConfig{
-		ServerName:    cfg.ServerName,
-		ServerVersion: cfg.ServerVersion,
-		OBSHost:       cfg.OBSHost,
-		OBSPort:       cfg.OBSPort,
-		OBSPassword:   cfg.OBSPassword,
-		DBPath:        cfg.DBPath,
-		HTTPEnabled:   cfg.WebServer.Enabled,
-		HTTPHost:      cfg.WebServer.Host,
-		HTTPPort:      cfg.WebServer.Port,
+		ServerName:        cfg.ServerName,
+		ServerVersion:     cfg.ServerVersion,
+		OBSHost:           cfg.OBSHost,
+		OBSPort:           cfg.OBSPort,
+		OBSPassword:       cfg.OBSPassword,
+		DBPath:            cfg.DBPath,
+		HTTPEnabled:       cfg.WebServer.Enabled,
+		HTTPHost:          cfg.WebServer.Host,
+		HTTPPort:          cfg.WebServer.Port,
+		ThumbnailCacheSec: cfg.WebServer.ThumbnailCacheSec,
 		ToolGroups: mcp.ToolGroupConfig{
 			Core:    cfg.ToolGroups.Core,
 			Visual:  cfg.ToolGroups.Visual,


### PR DESCRIPTION
## Summary

Integrates the `pkg/mcpui` SDK with the agentic-obs MCP server to provide rich, interactive UI resources for AI clients.

### Phase 1-2: Infrastructure
- HTTP routes at `/ui/*` for status, scenes, audio, and screenshots
- `StatusProvider` interface decouples HTTP handlers from OBS/MCP dependencies
- `ActionExecutor` interface enables UI actions to trigger tool calls
- Shared CSS design system matching existing dashboard theme

### Phase 3: Scene Preview UI
- Live scene thumbnails via `/ui/scene-thumbnail/{name}`
- Source count badges on scene cards
- Keyboard navigation (1-9 quick switch, arrows, Enter)
- Loading states during scene transitions

### Phase 4: Audio Mixer UI
- Visual channel cards with input kind badges
- Gradient-filled slider track (green → yellow → red)
- SVG speaker icons for mute/unmute toggle
- dB scale markers (-∞, -20, -10, 0 dB)
- Auto-refresh every 3 seconds (non-intrusive)
- Keyboard navigation (↑↓ channels, ←→ volume, M mute, 0 reset)

## Test Plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests for UI handlers (25+ test cases)
- [x] Scene thumbnail endpoint returns images or SVG placeholders
- [x] Audio mixer renders with muted/unmuted states
- [x] Action handler executes tools and returns proper responses
- [x] Manual: Start server, visit `http://localhost:8765/ui/status`
- [x] Manual: Verify scene switching works from UI
- [x] Manual: Verify audio mute/volume controls work

🤖 Generated with [Claude Code](https://claude.com/claude-code)