### PR TITLE
FB-17: Add configuration sync and version injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 /.claude/**
 agentic-obs.exe
+
+# MCP project files
+manifest.json
+*.mcpb
+
+# Windows special files
+nul

--- a/main.go
+++ b/main.go
@@ -16,10 +16,10 @@ import (
 	"github.com/ironystock/agentic-obs/internal/tui"
 )
 
-const (
-	appName    = "agentic-obs"
-	appVersion = "0.1.0"
-)
+const appName = "agentic-obs"
+
+// appVersion uses the build-time injected version from version.go
+var appVersion = version
 
 func main() {
 	// Parse command-line flags
@@ -37,7 +37,10 @@ func main() {
 	// Set up logging with timestamps and source location
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	log.Printf("========================================")
-	log.Printf("Starting %s v%s", appName, appVersion)
+	log.Printf("Starting %s v%s", appName, Version())
+	if commit != "none" {
+		log.Printf("Build: %s (%s)", commit, date)
+	}
 	log.Printf("========================================")
 
 	// Create context for initialization
@@ -170,26 +173,8 @@ func loadConfig(ctx context.Context) (*config.Config, error) {
 	cfg.ServerName = appName
 	cfg.ServerVersion = appVersion
 
-	// Check for environment variable overrides
-	if obsHost := os.Getenv("OBS_HOST"); obsHost != "" {
-		log.Printf("Using OBS_HOST from environment: %s", obsHost)
-		cfg.OBSHost = obsHost
-	}
-
-	if obsPort := os.Getenv("OBS_PORT"); obsPort != "" {
-		log.Printf("Using OBS_PORT from environment: %s", obsPort)
-		cfg.OBSPort = obsPort
-	}
-
-	if obsPassword := os.Getenv("OBS_PASSWORD"); obsPassword != "" {
-		log.Println("Using OBS_PASSWORD from environment")
-		cfg.OBSPassword = obsPassword
-	}
-
-	if dbPath := os.Getenv("DB_PATH"); dbPath != "" {
-		log.Printf("Using DB_PATH from environment: %s", dbPath)
-		cfg.DBPath = dbPath
-	}
+	// Apply environment variable overrides (takes precedence over stored config)
+	cfg.ApplyEnvOverrides()
 
 	// Run first-run setup prompts if this is first run
 	if isFirstRun {
@@ -327,10 +312,12 @@ Options:
   -h, --help    Show this help message
 
 Environment Variables:
-  OBS_HOST      OBS WebSocket host (default: localhost)
-  OBS_PORT      OBS WebSocket port (default: 4455)
-  OBS_PASSWORD  OBS WebSocket password (default: empty)
-  DB_PATH       Database file path (default: ~/.agentic-obs/db.sqlite)
+  OBS_HOST                   OBS WebSocket host (default: localhost)
+  OBS_PORT                   OBS WebSocket port (default: 4455)
+  OBS_PASSWORD               OBS WebSocket password (default: empty)
+  AGENTIC_OBS_DB             Database file path (default: ~/.agentic-obs/db.sqlite)
+  AGENTIC_OBS_HTTP_PORT      HTTP server port (default: 8765)
+  AGENTIC_OBS_HTTP_ENABLED   Enable/disable HTTP server (default: true)
 
 Examples:
   # Run MCP server (default mode)

--- a/skills/README.md
+++ b/skills/README.md
@@ -262,6 +262,6 @@ For issues with skills or agentic-obs:
 
 ---
 
-**Last Updated**: 2025-12-18
-**agentic-obs Version**: 1.0.0
+**Last Updated**: 2025-12-19
+**agentic-obs Version**: 0.8.0
 **Skills Version**: 1.0.0

--- a/version.go
+++ b/version.go
@@ -1,0 +1,36 @@
+package main
+
+// Build-time variables injected via ldflags.
+// These are set during build with:
+//
+//	go build -ldflags "-X main.version=1.0.0 -X main.commit=abc1234 -X main.date=2025-01-01"
+//
+// If not set, defaults are used for development builds.
+var (
+	// version is the semantic version (e.g., "1.0.0", "1.0.0-beta.1")
+	version = "dev"
+
+	// commit is the git commit hash (short form)
+	commit = "none"
+
+	// date is the build date in ISO 8601 format
+	date = "unknown"
+)
+
+// Version returns the full version string including build metadata.
+func Version() string {
+	if version == "dev" {
+		return "dev (commit: " + commit + ", built: " + date + ")"
+	}
+	return version
+}
+
+// VersionShort returns just the semantic version.
+func VersionShort() string {
+	return version
+}
+
+// BuildInfo returns detailed build information.
+func BuildInfo() (ver, com, dat string) {
+	return version, commit, date
+}


### PR DESCRIPTION
## Summary

This PR implements configuration synchronization and build-time version injection.

### Environment Variable Support
- **`ApplyEnvOverrides()`** - New consolidated method in config package
- **OBS Settings**: `OBS_HOST`, `OBS_PORT`, `OBS_PASSWORD`
- **Database**: `AGENTIC_OBS_DB` (with `DB_PATH` legacy alias)
- **HTTP Server**: `AGENTIC_OBS_HTTP_PORT`, `AGENTIC_OBS_HTTP_ENABLED`
- Env vars take precedence over database-stored config

### Version Injection
- **`version.go`** - Build-time variables via ldflags
- Supports `version`, `commit`, `date` injection
- Development builds show `dev (commit: none, built: unknown)`
- Production builds via: `go build -ldflags "-X main.version=1.0.0 ..."`

### Version Consistency
- Removed hardcoded `0.1.0` from config.go
- Updated skills/README.md to `0.8.0`
- Enhanced help text with full env var documentation

### Other
- Added `manifest.json`, `*.mcpb`, `nul` to .gitignore

## Test Plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] Verify env vars override config: `OBS_HOST=example.com ./agentic-obs`
- [x] Verify version injection: `go build -ldflags "-X main.version=test" && ./agentic-obs --help`

## Files Changed
| File | Change |
|------|--------|
| `config/config.go` | Add `ApplyEnvOverrides()`, env var constants |
| `main.go` | Use injected version, consolidated env handling |
| `version.go` | New - build-time version variables |
| `skills/README.md` | Version update |
| `.gitignore` | Add MCP project files |

🤖 Generated with [Claude Code](https://claude.com/claude-code)