### PR TITLE
Add Filters and Transitions tool groups (FB-23, FB-24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Context for AI assistants working on the agentic-obs project.
 
 **agentic-obs** is an MCP (Model Context Protocol) server providing AI assistants with programmatic control over OBS Studio via the WebSocket API.
 
-**Current Status:** 45 Tools | 4 Resources | 13 Prompts | 4 Skills
+**Current Status:** 57 Tools | 4 Resources | 13 Prompts | 4 Skills
 
 ## Project Structure
 
@@ -17,7 +17,7 @@ agentic-obs/
 ├── internal/
 │   ├── mcp/
 │   │   ├── server.go       # MCP server lifecycle
-│   │   ├── tools.go        # Tool registration (45 tools)
+│   │   ├── tools.go        # Tool registration (57 tools)
 │   │   ├── resources.go    # Resource handlers (4 types)
 │   │   ├── prompts.go      # Prompt definitions (13 prompts)
 │   │   ├── completions.go  # Autocomplete handler
@@ -56,7 +56,7 @@ agentic-obs/
 AI Assistant (Claude)
     ↕ stdio (JSON-RPC)
 MCP Server (agentic-obs)
-    ├─ Tools (45) ─────────┐
+    ├─ Tools (57) ─────────┐
     ├─ Resources (4) ──────┼─→ OBS Client ─→ OBS Studio
     ├─ Prompts (13) ───────┘      ↕ WebSocket (4455)
     └─ Storage ─────────────→ SQLite
@@ -150,7 +150,7 @@ go mod tidy
 
 ## MCP Capabilities Summary
 
-### Tools (45 in 6 groups)
+### Tools (57 in 8 groups)
 
 | Group | Count | Examples |
 |-------|-------|----------|
@@ -160,6 +160,8 @@ go mod tidy
 | Layout | 6 | `save_scene_preset`, `apply_scene_preset` |
 | Visual | 4 | `create_screenshot_source`, `list_screenshot_sources` |
 | Design | 14 | `create_text_source`, `set_source_transform` |
+| Filters | 7 | `list_source_filters`, `toggle_source_filter` |
+| Transitions | 5 | `list_transitions`, `set_current_transition` |
 | Help | 1 | `help` (always enabled) |
 
 ### Resources (4 types)
@@ -182,7 +184,7 @@ For detailed rationale, see [design/decisions/](design/decisions/).
 1. **Pure Go SQLite** (`modernc.org/sqlite`) - No CGO for easy cross-compilation
 2. **Persistent OBS Connection** - Single 1:1 connection with auto-reconnect
 3. **Scenes as Resources** - Enable MCP notifications for state synchronization
-4. **Tool Groups** - Configurable categories (Core, Visual, Layout, Audio, Sources, Design)
+4. **Tool Groups** - Configurable categories (Core, Visual, Layout, Audio, Sources, Design, Filters, Transitions)
 5. **Interface Pattern** - StatusProvider/ActionExecutor for web UI decoupling
 
 ## Documentation Links

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This MCP server provides AI agents (like Claude) with programmatic control over 
 
 ## Features
 
-- **45 MCP Tools**: Comprehensive control over OBS Studio operations in 6 tool groups
+- **57 MCP Tools**: Comprehensive control over OBS Studio operations in 8 tool groups
 - **Scene Management**: List, switch, create, and remove OBS scenes
 - **Scene Presets**: Save and restore source visibility configurations
 - **Recording Control**: Start, stop, pause, resume, and monitor recording
@@ -242,7 +242,29 @@ Enable AI to create and manipulate OBS sources programmatically.
 | `remove_source` | Remove a source from a scene |
 | `list_input_kinds` | List all available input source types |
 
-**Total: 45 tools in 6 groups** (Core, Sources, Audio, Layout, Visual, Design) + Help
+### Filters (7 tools)
+
+| Tool | Description |
+|------|-------------|
+| `list_source_filters` | List all filters applied to a source |
+| `get_source_filter` | Get filter details and settings |
+| `create_source_filter` | Add a new filter to a source (color correction, noise suppression, etc.) |
+| `remove_source_filter` | Remove a filter from a source |
+| `toggle_source_filter` | Enable/disable a filter |
+| `set_source_filter_settings` | Modify filter configuration |
+| `list_filter_kinds` | List all available filter types |
+
+### Transitions (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `list_transitions` | List all available transitions and current one |
+| `get_current_transition` | Get current transition details |
+| `set_current_transition` | Change the active transition (Cut, Fade, Swipe, etc.) |
+| `set_transition_duration` | Set transition duration in milliseconds |
+| `trigger_transition` | Trigger studio mode transition (preview to program) |
+
+**Total: 57 tools in 8 groups** (Core, Sources, Audio, Layout, Visual, Design, Filters, Transitions) + Help
 
 ## MCP Resources
 
@@ -293,7 +315,7 @@ agentic-obs/
 ├── main.go                 # Entry point (MCP server or TUI)
 ├── config/                 # Configuration management
 ├── internal/
-│   ├── mcp/               # MCP server implementation (45 tools)
+│   ├── mcp/               # MCP server implementation (57 tools)
 │   ├── obs/               # OBS WebSocket client
 │   ├── storage/           # SQLite persistence
 │   ├── http/              # HTTP server for screenshots and dashboard

--- a/design/ARCHITECTURE.md
+++ b/design/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document describes the system architecture of agentic-obs.
 
 ## System Overview
 
-agentic-obs is an MCP (Model Context Protocol) server that bridges AI assistants with OBS Studio. It provides 45 tools, 4 resource types, and 13 prompts for programmatic OBS control.
+agentic-obs is an MCP (Model Context Protocol) server that bridges AI assistants with OBS Studio. It provides 57 tools, 4 resource types, and 13 prompts for programmatic OBS control.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐

--- a/design/README.md
+++ b/design/README.md
@@ -19,6 +19,6 @@ This directory contains architecture documents, design decisions, and roadmap fo
 
 ## Quick Links
 
-**Current Status:** 45 Tools | 4 Resources | 13 Prompts
+**Current Status:** 57 Tools | 4 Resources | 13 Prompts
 
 See [decisions/](decisions/) for the rationale behind key architectural choices.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Complete documentation for controlling OBS Studio with AI through the Model Cont
 ## Getting Started
 
 - **[Quick Start Guide](QUICKSTART.md)** - Get up and running in 10 minutes
-- **[Tool Reference](TOOLS.md)** - Comprehensive reference for all 45 MCP tools
+- **[Tool Reference](TOOLS.md)** - Comprehensive reference for all 57 MCP tools
 - **[Screenshot Guide](SCREENSHOTS.md)** - AI visual monitoring of your stream
 - **[HTTP API Reference](API.md)** - REST API for monitoring and configuration
 
@@ -19,7 +19,7 @@ Complete documentation for controlling OBS Studio with AI through the Model Cont
 | Document | Description |
 |----------|-------------|
 | [QUICKSTART.md](QUICKSTART.md) | Step-by-step installation and setup guide |
-| [TOOLS.md](TOOLS.md) | Complete reference for all 45 tools with examples |
+| [TOOLS.md](TOOLS.md) | Complete reference for all 57 tools with examples |
 | [SCREENSHOTS.md](SCREENSHOTS.md) | Detailed guide to AI visual monitoring |
 | [API.md](API.md) | HTTP REST API reference for monitoring and config |
 | [../README.md](../README.md) | Project overview and features |
@@ -78,9 +78,15 @@ Built-in help system with topic-based guidance
 ### Scene Design (14 tools)
 Create and manipulate sources (text, image, color, browser, media, transforms)
 
+### Filters (7 tools)
+Manage source filters - color correction, noise suppression, and other effects
+
+### Transitions (5 tools)
+Control scene transitions - list, set, configure duration, and trigger
+
 ---
 
-**Total: 45 MCP tools available**
+**Total: 57 MCP tools available**
 
 For detailed information on each tool, see [TOOLS.md](TOOLS.md).
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -67,7 +67,7 @@ Comprehensive documentation for all 45 Model Context Protocol (MCP) tools provid
 
 ## Overview
 
-The agentic-obs MCP server provides 45 tools organized into 10 categories (6 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
+The agentic-obs MCP server provides 57 tools organized into 12 categories (8 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
 
 | Category | Tools | Description | Tool Group |
 |----------|-------|-------------|------------|
@@ -81,6 +81,8 @@ The agentic-obs MCP server provides 45 tools organized into 10 categories (6 too
 | Status | 1 | Overall OBS status | Core |
 | Help & Discovery | 1 | Topic-based help system | Always enabled |
 | Scene Design | 14 | Source creation and manipulation | Design |
+| Filters | 7 | Filter creation, toggle, settings | Filters |
+| Transitions | 5 | Transition control and configuration | Transitions |
 
 **General Prerequisites:**
 - OBS Studio 28+ running with WebSocket server enabled

--- a/internal/docs/content/README.md
+++ b/internal/docs/content/README.md
@@ -8,7 +8,7 @@ This MCP server provides AI agents (like Claude) with programmatic control over 
 
 ## Features
 
-- **45 MCP Tools**: Comprehensive control over OBS Studio operations in 6 tool groups
+- **57 MCP Tools**: Comprehensive control over OBS Studio operations in 8 tool groups
 - **Scene Management**: List, switch, create, and remove OBS scenes
 - **Scene Presets**: Save and restore source visibility configurations
 - **Recording Control**: Start, stop, pause, resume, and monitor recording
@@ -242,7 +242,29 @@ Enable AI to create and manipulate OBS sources programmatically.
 | `remove_source` | Remove a source from a scene |
 | `list_input_kinds` | List all available input source types |
 
-**Total: 45 tools in 6 groups** (Core, Sources, Audio, Layout, Visual, Design) + Help
+### Filters (7 tools)
+
+| Tool | Description |
+|------|-------------|
+| `list_source_filters` | List all filters applied to a source |
+| `get_source_filter` | Get filter details and settings |
+| `create_source_filter` | Add a new filter to a source (color correction, noise suppression, etc.) |
+| `remove_source_filter` | Remove a filter from a source |
+| `toggle_source_filter` | Enable/disable a filter |
+| `set_source_filter_settings` | Modify filter configuration |
+| `list_filter_kinds` | List all available filter types |
+
+### Transitions (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `list_transitions` | List all available transitions and current one |
+| `get_current_transition` | Get current transition details |
+| `set_current_transition` | Change the active transition (Cut, Fade, Swipe, etc.) |
+| `set_transition_duration` | Set transition duration in milliseconds |
+| `trigger_transition` | Trigger studio mode transition (preview to program) |
+
+**Total: 57 tools in 8 groups** (Core, Sources, Audio, Layout, Visual, Design, Filters, Transitions) + Help
 
 ## MCP Resources
 
@@ -293,7 +315,7 @@ agentic-obs/
 ├── main.go                 # Entry point (MCP server or TUI)
 ├── config/                 # Configuration management
 ├── internal/
-│   ├── mcp/               # MCP server implementation (45 tools)
+│   ├── mcp/               # MCP server implementation (57 tools)
 │   ├── obs/               # OBS WebSocket client
 │   ├── storage/           # SQLite persistence
 │   ├── http/              # HTTP server for screenshots and dashboard

--- a/internal/docs/content/TOOLS.md
+++ b/internal/docs/content/TOOLS.md
@@ -67,7 +67,7 @@ Comprehensive documentation for all 45 Model Context Protocol (MCP) tools provid
 
 ## Overview
 
-The agentic-obs MCP server provides 45 tools organized into 10 categories (6 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
+The agentic-obs MCP server provides 57 tools organized into 12 categories (8 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
 
 | Category | Tools | Description | Tool Group |
 |----------|-------|-------------|------------|
@@ -81,6 +81,8 @@ The agentic-obs MCP server provides 45 tools organized into 10 categories (6 too
 | Status | 1 | Overall OBS status | Core |
 | Help & Discovery | 1 | Topic-based help system | Always enabled |
 | Scene Design | 14 | Source creation and manipulation | Design |
+| Filters | 7 | Filter creation, toggle, settings | Filters |
+| Transitions | 5 | Transition control and configuration | Transitions |
 
 **General Prerequisites:**
 - OBS Studio 28+ running with WebSocket server enabled

--- a/internal/docs/embed.go
+++ b/internal/docs/embed.go
@@ -30,7 +30,7 @@ var docMeta = map[string]struct {
 	description string
 }{
 	"README":          {"Getting Started", "Project overview, features, and installation"},
-	"TOOLS":           {"Tool Reference", "Complete reference for all 45 MCP tools"},
+	"TOOLS":           {"Tool Reference", "Complete reference for all 57 MCP tools"},
 	"TROUBLESHOOTING": {"Troubleshooting", "Common issues and solutions"},
 	"QUICKSTART":      {"Quick Start Guide", "Step-by-step setup instructions"},
 	"BUILD":           {"Building from Source", "Build, test, and release instructions"},

--- a/internal/mcp/elicitation.go
+++ b/internal/mcp/elicitation.go
@@ -70,6 +70,12 @@ func ElicitDeleteConfirmation(ctx context.Context, session *mcpsdk.ServerSession
 		fmt.Sprintf("You are about to permanently delete %s '%s'. This cannot be undone. Continue?", itemType, itemName))
 }
 
+// ElicitFilterRemovalConfirmation requests confirmation before removing a filter from a source.
+func ElicitFilterRemovalConfirmation(ctx context.Context, session *mcpsdk.ServerSession, sourceName, filterName string) (bool, error) {
+	return ElicitConfirmation(ctx, session,
+		fmt.Sprintf("You are about to remove filter '%s' from source '%s'. This cannot be undone. Continue?", filterName, sourceName))
+}
+
 // CancelledResult returns a result indicating the action was cancelled by the user.
 func CancelledResult(action string) SimpleResult {
 	return SimpleResult{Message: fmt.Sprintf("%s cancelled by user", action)}

--- a/internal/mcp/help_content.go
+++ b/internal/mcp/help_content.go
@@ -21,18 +21,20 @@ import "fmt"
 //
 // ============================================================================
 const (
-	HelpToolCount     = 45 // Total MCP tools (including help)
+	HelpToolCount     = 57 // Total MCP tools (including help)
 	HelpResourceCount = 4  // Resource types: scenes, screenshots, screenshot-url, presets
 	HelpPromptCount   = 13 // Workflow prompts
 
 	// Tool counts by category (should sum to HelpToolCount)
-	HelpCoreToolCount    = 13 // Scene management, recording, streaming, status
-	HelpHelpToolCount    = 1  // The help tool itself
-	HelpSourcesToolCount = 3  // Source management
-	HelpAudioToolCount   = 4  // Audio control
-	HelpLayoutToolCount  = 6  // Scene presets
-	HelpVisualToolCount  = 4  // Screenshot monitoring
-	HelpDesignToolCount  = 14 // Source creation and layout
+	HelpCoreToolCount        = 13 // Scene management, recording, streaming, status
+	HelpHelpToolCount        = 1  // The help tool itself
+	HelpSourcesToolCount     = 3  // Source management
+	HelpAudioToolCount       = 4  // Audio control
+	HelpLayoutToolCount      = 6  // Scene presets
+	HelpVisualToolCount      = 4  // Screenshot monitoring
+	HelpDesignToolCount      = 14 // Source creation and layout
+	HelpFiltersToolCount     = 7  // Filter management (FB-23)
+	HelpTransitionsToolCount = 5  // Transition control (FB-24)
 )
 
 // GetOverviewHelp returns high-level overview of agentic-obs
@@ -51,7 +53,7 @@ A Model Context Protocol (MCP) server that gives AI assistants programmatic cont
 
 ## Key Features
 
-- **%d Tools** across 6 categories (Core, Sources, Audio, Layout, Visual, Design) + Help
+- **%d Tools** across 8 categories (Core, Sources, Audio, Layout, Visual, Design, Filters, Transitions) + Help
 - **%d Resource Types** (scenes, screenshots, screenshot URLs, presets)
 - **%d Workflow Prompts** for common streaming/recording tasks
 - **Real-time Monitoring** via screenshot sources for AI visual inspection
@@ -69,6 +71,8 @@ A Model Context Protocol (MCP) server that gives AI assistants programmatic cont
 **Layout Tools** (%d tools): Scene preset save/restore/manage
 **Visual Tools** (%d tools): Screenshot source creation and monitoring
 **Design Tools** (%d tools): Source creation, transforms, positioning
+**Filters Tools** (%d tools): Filter creation, toggle, settings
+**Transitions Tools** (%d tools): Transition selection, duration, trigger
 
 ## Common Workflows
 
@@ -85,7 +89,8 @@ A Model Context Protocol (MCP) server that gives AI assistants programmatic cont
 - topic="prompts" - Discover pre-built workflow prompts
 - topic="troubleshooting" - Common issues and solutions
 `, HelpCoreToolCount, HelpSourcesToolCount, HelpAudioToolCount,
-			HelpLayoutToolCount, HelpVisualToolCount, HelpDesignToolCount)
+			HelpLayoutToolCount, HelpVisualToolCount, HelpDesignToolCount,
+			HelpFiltersToolCount, HelpTransitionsToolCount)
 	}
 
 	return help
@@ -172,8 +177,27 @@ func GetToolsHelp(verbose bool) string {
 - duplicate_source - Copy source within/between scenes
 - remove_source - Delete source from scene
 - list_input_kinds - List all available OBS source types
+
+## Filters Tools (%d tools) - Filter Management
+
+- list_source_filters - List all filters on a source
+- get_source_filter - Get filter details and settings
+- create_source_filter - Add a new filter (color correction, noise suppression, etc.)
+- remove_source_filter - Remove a filter from source
+- toggle_source_filter - Enable/disable a filter
+- set_source_filter_settings - Modify filter configuration
+- list_filter_kinds - List all available filter types
+
+## Transitions Tools (%d tools) - Scene Transition Control
+
+- list_transitions - List available transitions and current one
+- get_current_transition - Get current transition details
+- set_current_transition - Change active transition (Cut, Fade, Swipe, etc.)
+- set_transition_duration - Set transition duration in milliseconds
+- trigger_transition - Trigger studio mode transition (preview to program)
 `, HelpToolCount, HelpCoreToolCount, HelpHelpToolCount, HelpSourcesToolCount,
-		HelpAudioToolCount, HelpLayoutToolCount, HelpVisualToolCount, HelpDesignToolCount)
+		HelpAudioToolCount, HelpLayoutToolCount, HelpVisualToolCount, HelpDesignToolCount,
+		HelpFiltersToolCount, HelpTransitionsToolCount)
 
 	if verbose {
 		help += `
@@ -191,6 +215,8 @@ Tools are organized by capability. You can:
 - Use Visual tools to let AI "see" your stream
 - Use Layout tools to save/restore complex setups
 - Use Design tools to build scenes programmatically
+- Use Filters tools to manage source effects (color correction, noise suppression)
+- Use Transitions tools to control scene change animations
 `
 	}
 

--- a/internal/mcp/help_test.go
+++ b/internal/mcp/help_test.go
@@ -443,7 +443,7 @@ func TestGetOverviewHelp(t *testing.T) {
 		assert.Contains(t, help, "What is agentic-obs")
 		assert.Contains(t, help, "Quick Start")
 		assert.Contains(t, help, "Key Features")
-		assert.Contains(t, help, "45 Tools")
+		assert.Contains(t, help, "57 Tools")
 		assert.Contains(t, help, "4 Resource Types")
 	})
 
@@ -454,6 +454,8 @@ func TestGetOverviewHelp(t *testing.T) {
 		assert.Contains(t, help, "Next Steps")
 		assert.Contains(t, help, "Core Tools")
 		assert.Contains(t, help, "Design Tools")
+		assert.Contains(t, help, "Filters Tools")
+		assert.Contains(t, help, "Transitions Tools")
 	})
 }
 
@@ -469,12 +471,16 @@ func TestGetToolsHelp(t *testing.T) {
 		assert.Contains(t, help, "Layout Tools")
 		assert.Contains(t, help, "Visual Tools")
 		assert.Contains(t, help, "Design Tools")
+		assert.Contains(t, help, "Filters Tools")
+		assert.Contains(t, help, "Transitions Tools")
 
 		// Check a few tool names
 		assert.Contains(t, help, "list_scenes")
 		assert.Contains(t, help, "start_recording")
 		assert.Contains(t, help, "create_screenshot_source")
 		assert.Contains(t, help, "save_scene_preset")
+		assert.Contains(t, help, "list_source_filters")
+		assert.Contains(t, help, "list_transitions")
 	})
 
 	t.Run("verbose tools help includes guidance", func(t *testing.T) {
@@ -662,7 +668,7 @@ func TestHelpContentCompleteness(t *testing.T) {
 	})
 
 	t.Run("all tool names have help entries", func(t *testing.T) {
-		// List of all 45 tools that should have help
+		// List of all 57 tools that should have help
 		allTools := []string{
 			// Core (13 tools)
 			"list_scenes", "set_current_scene", "create_scene", "remove_scene",
@@ -685,6 +691,13 @@ func TestHelpContentCompleteness(t *testing.T) {
 			"set_source_transform", "get_source_transform", "set_source_crop",
 			"set_source_bounds", "set_source_order",
 			"set_source_locked", "duplicate_source", "remove_source", "list_input_kinds",
+			// Filters (7 tools)
+			"list_source_filters", "get_source_filter", "create_source_filter",
+			"remove_source_filter", "toggle_source_filter", "set_source_filter_settings",
+			"list_filter_kinds",
+			// Transitions (5 tools)
+			"list_transitions", "get_current_transition", "set_current_transition",
+			"set_transition_duration", "trigger_transition",
 		}
 
 		for _, toolName := range allTools {

--- a/internal/mcp/help_tools.go
+++ b/internal/mcp/help_tools.go
@@ -1006,6 +1006,308 @@ var toolHelpContent = map[string]string{
 }
 
 **Use Case**: Discover available source types for your OBS installation.`,
+
+	// Filters (FB-23)
+	"list_source_filters": `# list_source_filters
+
+**Category**: Filters
+
+**Description**: List all filters applied to a source.
+
+**Input**:
+- source_name (string, required): Name of the source to list filters for
+
+**Output**:
+- source_name: Source name
+- filters: Array of filter objects (name, kind, index, enabled)
+- count: Total number of filters
+
+**Example Input**:
+{
+  "source_name": "Webcam"
+}
+
+**Example Output**:
+{
+  "source_name": "Webcam",
+  "filters": [
+    {"name": "Color Correction", "kind": "color_filter_v2", "index": 0, "enabled": true},
+    {"name": "Sharpen", "kind": "sharpness_filter_v2", "index": 1, "enabled": true}
+  ],
+  "count": 2
+}`,
+
+	"get_source_filter": `# get_source_filter
+
+**Category**: Filters
+
+**Description**: Get detailed information about a specific filter on a source.
+
+**Input**:
+- source_name (string, required): Name of the source containing the filter
+- filter_name (string, required): Name of the filter to get details for
+
+**Output**:
+- source_name: Source name
+- filter: Filter details (name, kind, index, enabled, settings)
+
+**Example Input**:
+{
+  "source_name": "Webcam",
+  "filter_name": "Color Correction"
+}
+
+**Use Case**: Inspect filter configuration before modifying settings.`,
+
+	"create_source_filter": `# create_source_filter
+
+**Category**: Filters
+
+**Description**: Add a new filter to a source (e.g., color correction, noise suppression).
+
+**Input**:
+- source_name (string, required): Name of the source to add the filter to
+- filter_name (string, required): Name for the new filter
+- filter_kind (string, required): Type of filter (use list_filter_kinds to see available types)
+- filter_settings (object, optional): Initial settings for the filter
+
+**Output**:
+- source_name: Source name
+- filter_name: Filter name
+- filter_kind: Filter type
+- message: Success confirmation
+
+**Example Input**:
+{
+  "source_name": "Webcam",
+  "filter_name": "My Color Correction",
+  "filter_kind": "color_filter_v2",
+  "filter_settings": {"brightness": 0.1, "contrast": 0.05}
+}
+
+**Common Filter Types**:
+- color_filter_v2: Color correction (brightness, contrast, saturation)
+- sharpness_filter_v2: Image sharpening
+- noise_suppress_filter_v2: Audio noise suppression
+- compressor_filter: Audio compressor
+- chroma_key_filter_v2: Green screen removal`,
+
+	"remove_source_filter": `# remove_source_filter
+
+**Category**: Filters
+
+**Description**: Remove a filter from a source.
+
+**Input**:
+- source_name (string, required): Name of the source containing the filter
+- filter_name (string, required): Name of the filter to remove
+
+**Output**:
+- source_name: Source name
+- filter_name: Filter name
+- message: Success confirmation
+
+**Example Input**:
+{
+  "source_name": "Webcam",
+  "filter_name": "Old Filter"
+}
+
+**Warning**: This action cannot be undone. The filter configuration will be lost.`,
+
+	"toggle_source_filter": `# toggle_source_filter
+
+**Category**: Filters
+
+**Description**: Enable or disable a filter on a source.
+
+**Input**:
+- source_name (string, required): Name of the source containing the filter
+- filter_name (string, required): Name of the filter to toggle
+- filter_enabled (bool, optional): Set to true/false to enable/disable; omit to toggle
+
+**Output**:
+- source_name: Source name
+- filter_name: Filter name
+- filter_enabled: New enabled state
+- message: Success confirmation
+
+**Example Input** (toggle):
+{
+  "source_name": "Webcam",
+  "filter_name": "Color Correction"
+}
+
+**Example Input** (explicit):
+{
+  "source_name": "Webcam",
+  "filter_name": "Color Correction",
+  "filter_enabled": false
+}
+
+**Use Case**: Quickly enable/disable effects without removing the filter.`,
+
+	"set_source_filter_settings": `# set_source_filter_settings
+
+**Category**: Filters
+
+**Description**: Modify the configuration settings of a filter.
+
+**Input**:
+- source_name (string, required): Name of the source containing the filter
+- filter_name (string, required): Name of the filter to update
+- filter_settings (object, required): Settings to apply to the filter
+- overlay (bool, optional): If true, merge with existing settings; if false, replace entirely (default: true)
+
+**Output**:
+- source_name: Source name
+- filter_name: Filter name
+- overlay: Whether overlay mode was used
+- message: Success confirmation
+
+**Example Input**:
+{
+  "source_name": "Webcam",
+  "filter_name": "Color Correction",
+  "filter_settings": {"brightness": 0.2, "saturation": 0.1},
+  "overlay": true
+}
+
+**Note**: Use overlay=true to update specific settings while keeping others unchanged.`,
+
+	"list_filter_kinds": `# list_filter_kinds
+
+**Category**: Filters
+
+**Description**: List all available filter types in OBS.
+
+**Input**: None
+
+**Output**:
+- filter_kinds: Array of available filter type IDs
+- count: Total number of types
+
+**Example Output**:
+{
+  "filter_kinds": [
+    "color_filter_v2",
+    "sharpness_filter_v2",
+    "noise_suppress_filter_v2",
+    "compressor_filter",
+    "limiter_filter",
+    "gain_filter",
+    "chroma_key_filter_v2"
+  ],
+  "count": 15
+}
+
+**Use Case**: Discover available filter types before creating filters with create_source_filter.`,
+
+	// Transitions (FB-24)
+	"list_transitions": `# list_transitions
+
+**Category**: Transitions
+
+**Description**: List all available scene transitions and identify the current one.
+
+**Input**: None
+
+**Output**:
+- transitions: Array of transition objects (name, kind, fixed, configurable)
+- current_transition: Name of currently active transition
+- count: Total number of transitions
+
+**Example Output**:
+{
+  "transitions": [
+    {"name": "Cut", "kind": "cut_transition", "fixed": true, "configurable": false},
+    {"name": "Fade", "kind": "fade_transition", "fixed": false, "configurable": true},
+    {"name": "Swipe", "kind": "swipe_transition", "fixed": false, "configurable": true}
+  ],
+  "current_transition": "Fade",
+  "count": 3
+}`,
+
+	"get_current_transition": `# get_current_transition
+
+**Category**: Transitions
+
+**Description**: Get details about the current scene transition including duration and settings.
+
+**Input**: None
+
+**Output**:
+- name: Transition name
+- kind: Transition type
+- duration_ms: Transition duration in milliseconds
+- configurable: Whether transition has configurable settings
+- settings: Current transition settings (if configurable)
+
+**Example Output**:
+{
+  "name": "Fade",
+  "kind": "fade_transition",
+  "duration_ms": 300,
+  "configurable": true,
+  "settings": {}
+}`,
+
+	"set_current_transition": `# set_current_transition
+
+**Category**: Transitions
+
+**Description**: Change the active scene transition (e.g., Cut, Fade, Swipe).
+
+**Input**:
+- transition_name (string, required): Name of the transition to set as current
+
+**Output**:
+- transition_name: Transition name
+- message: Success confirmation
+
+**Example Input**:
+{
+  "transition_name": "Fade"
+}
+
+**Use Case**: Change how scenes transition during scene switches.`,
+
+	"set_transition_duration": `# set_transition_duration
+
+**Category**: Transitions
+
+**Description**: Set the duration of the current scene transition in milliseconds.
+
+**Input**:
+- transition_duration (int, required): Duration in milliseconds
+
+**Output**:
+- duration_ms: New duration value
+- message: Success confirmation
+
+**Example Input**:
+{
+  "transition_duration": 500
+}
+
+**Note**: Typical durations range from 100ms (quick) to 1000ms (slow). Cut transition ignores duration.`,
+
+	"trigger_transition": `# trigger_transition
+
+**Category**: Transitions
+
+**Description**: Trigger the current transition in studio mode (swaps preview and program scenes).
+
+**Input**: None
+
+**Output**:
+- message: Success confirmation
+
+**Requirements**: OBS must be in Studio Mode for this to work.
+
+**Use Case**: Manually trigger scene changes in studio mode workflow.
+
+**Error Handling**: Returns error if studio mode is not enabled.`,
 }
 
 // GetToolHelpContent returns the help text for a specific tool, or empty if not found.

--- a/internal/mcp/interfaces.go
+++ b/internal/mcp/interfaces.go
@@ -74,6 +74,22 @@ type OBSClient interface {
 	// Scene design - input kinds
 	GetInputKindList() ([]string, error)
 
+	// Filter operations
+	GetSourceFilterList(sourceName string) ([]obs.FilterInfo, error)
+	GetSourceFilter(sourceName, filterName string) (*obs.FilterDetails, error)
+	CreateSourceFilter(sourceName, filterName, filterKind string, settings map[string]interface{}) error
+	RemoveSourceFilter(sourceName, filterName string) error
+	SetSourceFilterEnabled(sourceName, filterName string, enabled bool) error
+	SetSourceFilterSettings(sourceName, filterName string, settings map[string]interface{}, overlay bool) error
+	GetSourceFilterKindList() ([]string, error)
+
+	// Transition operations
+	GetSceneTransitionList() ([]obs.TransitionInfo, string, error)
+	GetCurrentSceneTransition() (*obs.TransitionDetails, error)
+	SetCurrentSceneTransition(transitionName string) error
+	SetCurrentSceneTransitionDuration(durationMs int) error
+	TriggerStudioModeTransition() error
+
 	// Event handling
 	SetEventCallback(callback obs.EventCallback)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -141,23 +141,27 @@ type ServerConfig struct {
 
 // ToolGroupConfig controls which tool categories are enabled
 type ToolGroupConfig struct {
-	Core    bool // Core OBS tools (scenes, recording, streaming, status)
-	Visual  bool // Visual monitoring tools (screenshots)
-	Layout  bool // Layout management tools (scene presets)
-	Audio   bool // Audio control tools
-	Sources bool // Source management tools
-	Design  bool // Scene design tools (source creation, transforms)
+	Core        bool // Core OBS tools (scenes, recording, streaming, status)
+	Visual      bool // Visual monitoring tools (screenshots)
+	Layout      bool // Layout management tools (scene presets)
+	Audio       bool // Audio control tools
+	Sources     bool // Source management tools
+	Design      bool // Scene design tools (source creation, transforms)
+	Filters     bool // Filter management tools (FB-23)
+	Transitions bool // Transition control tools (FB-24)
 }
 
 // DefaultToolGroupConfig returns config with all tool groups enabled
 func DefaultToolGroupConfig() ToolGroupConfig {
 	return ToolGroupConfig{
-		Core:    true,
-		Visual:  true,
-		Layout:  true,
-		Audio:   true,
-		Sources: true,
-		Design:  true,
+		Core:        true,
+		Visual:      true,
+		Layout:      true,
+		Audio:       true,
+		Sources:     true,
+		Design:      true,
+		Filters:     true,
+		Transitions: true,
 	}
 }
 

--- a/scripts/verify-docs.sh
+++ b/scripts/verify-docs.sh
@@ -14,11 +14,11 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Current expected values - UPDATE THESE AFTER EACH PHASE
-EXPECTED_TOOLS=45
+EXPECTED_TOOLS=57
 EXPECTED_RESOURCES=4
 EXPECTED_PROMPTS=13
 EXPECTED_API_ENDPOINTS=8
-CURRENT_PHASE=7
+CURRENT_PHASE=10
 
 echo "=========================================="
 echo "Documentation Consistency Verification"


### PR DESCRIPTION
## Summary

This PR adds **12 new MCP tools** across **2 new tool groups**, bringing the total from 45 to 57 tools:

### Filters (7 tools - FB-23)
| Tool | Description |
|------|-------------|
| `list_source_filters` | List all filters on a source |
| `get_source_filter` | Get filter details and settings |
| `create_source_filter` | Add filters (color correction, noise suppression) |
| `remove_source_filter` | Remove a filter (with elicitation confirmation) |
| `toggle_source_filter` | Enable/disable a filter |
| `set_source_filter_settings` | Modify filter configuration |
| `list_filter_kinds` | List available filter types |

### Transitions (5 tools - FB-24)
| Tool | Description |
|------|-------------|
| `list_transitions` | List available transitions and current one |
| `get_current_transition` | Get current transition details |
| `set_current_transition` | Change active transition (Cut, Fade, Swipe) |
| `set_transition_duration` | Set transition duration in milliseconds |
| `trigger_transition` | Trigger studio mode transition |

## Implementation Details

- **OBS Client Layer**: Added `FilterInfo`, `FilterDetails`, `TransitionInfo`, `TransitionDetails` types and 12 methods in `commands.go`
- **Interface Layer**: Extended `OBSClient` interface with 12 new methods
- **Mock Layer**: Full mock implementations with realistic test data
- **MCP Layer**: Input types, handlers, and tool registrations in `tools.go`
- **Elicitation**: User confirmation for `remove_source_filter` (destructive action)
- **Tool Groups**: Added `Filters` and `Transitions` to `ToolGroupConfig`
- **Documentation**: Updated all tool counts (45→57) and added help entries for all new tools

## Files Changed (19 files, +1733/-46 lines)

| Category | Files |
|----------|-------|
| OBS Client | `internal/obs/commands.go` |
| MCP Server | `internal/mcp/tools.go`, `server.go`, `interfaces.go`, `elicitation.go` |
| Testing | `internal/mcp/testutil/mock_obs.go`, `help_test.go` |
| Help System | `internal/mcp/help_content.go`, `help_tools.go` |
| Documentation | `README.md`, `CLAUDE.md`, `docs/TOOLS.md`, etc. |

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Documentation verification passes (`scripts/verify-docs.sh`)
- [x] Code compiles without errors
- [ ] Manual testing with OBS (filters and transitions operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)