### PR TITLE
Add Virtual Cam, Replay Buffer, Studio Mode & Hotkeys tools (FB-25, FB-26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.11.0] - 2025-12-21
+
+### Phase 11: Virtual Camera, Replay Buffer, Studio Mode & Hotkeys
+
+**Summary:** FB-25 and FB-26 - Advanced OBS output control and preview features.
+
+### Added
+- **Virtual Camera & Replay Buffer** (FB-25, 6 tools):
+  - `get_virtual_cam_status`, `toggle_virtual_cam` - Virtual camera control
+  - `get_replay_buffer_status`, `toggle_replay_buffer` - Replay buffer state
+  - `save_replay_buffer`, `get_last_replay` - Capture highlights
+- **Studio Mode & Hotkeys** (FB-26, 6 tools):
+  - `get_studio_mode_enabled`, `toggle_studio_mode` - Studio mode control
+  - `get_preview_scene`, `set_preview_scene` - Preview/program workflow
+  - `list_hotkeys`, `trigger_hotkey_by_name` - Hotkey automation
+
+### Changed
+- `stream-teardown` prompt: Scene switch now happens BEFORE stopping stream (proper ordering)
+- `health-check` prompt: Added virtual cam, replay buffer, studio mode, and hotkey checks
+- `recording-workflow` prompt: Integrated replay buffer for highlight capture
+
+### Tests
+- 15 new test functions with 36 test cases for FB-25/FB-26 handlers
+- 3 integration workflow tests (virtual cam, studio mode, hotkeys)
+
+### Metrics
+- **Tools:** 69 (+12)
+- **Resources:** 4 (unchanged)
+- **Prompts:** 13 (unchanged)
+
+---
+
+## [0.10.0] - 2025-12-20
+
+### Phase 10: Filters & Transitions
+
+**Summary:** FB-23 and FB-24 - Source filter management and scene transition control.
+
+### Added
+- **Filters Tool Group** (FB-23, 7 tools):
+  - `list_source_filters`, `get_source_filter` - Query filters
+  - `create_source_filter`, `remove_source_filter` - Manage filters
+  - `toggle_source_filter`, `set_source_filter_settings` - Configure filters
+  - `list_filter_kinds` - Discover available filter types
+- **Transitions Tool Group** (FB-24, 5 tools):
+  - `list_transitions`, `get_current_transition` - Query transitions
+  - `set_current_transition`, `set_transition_duration` - Configure transitions
+  - `trigger_transition` - Trigger studio mode transition
+
+### Metrics
+- **Tools:** 57 (+12)
+- **Resources:** 4 (unchanged)
+- **Prompts:** 13 (unchanged)
+
+---
+
 ## [0.7.0] - 2025-12-18
 
 ### Phase 7: MCP Completions, Help Tool & Claude Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Context for AI assistants working on the agentic-obs project.
 
 **agentic-obs** is an MCP (Model Context Protocol) server providing AI assistants with programmatic control over OBS Studio via the WebSocket API.
 
-**Current Status:** 57 Tools | 4 Resources | 13 Prompts | 4 Skills
+**Current Status:** 69 Tools | 4 Resources | 13 Prompts | 4 Skills
 
 ## Project Structure
 
@@ -17,7 +17,7 @@ agentic-obs/
 ├── internal/
 │   ├── mcp/
 │   │   ├── server.go       # MCP server lifecycle
-│   │   ├── tools.go        # Tool registration (57 tools)
+│   │   ├── tools.go        # Tool registration (69 tools)
 │   │   ├── resources.go    # Resource handlers (4 types)
 │   │   ├── prompts.go      # Prompt definitions (13 prompts)
 │   │   ├── completions.go  # Autocomplete handler
@@ -56,7 +56,7 @@ agentic-obs/
 AI Assistant (Claude)
     ↕ stdio (JSON-RPC)
 MCP Server (agentic-obs)
-    ├─ Tools (57) ─────────┐
+    ├─ Tools (69) ─────────┐
     ├─ Resources (4) ──────┼─→ OBS Client ─→ OBS Studio
     ├─ Prompts (13) ───────┘      ↕ WebSocket (4455)
     └─ Storage ─────────────→ SQLite
@@ -150,11 +150,11 @@ go mod tidy
 
 ## MCP Capabilities Summary
 
-### Tools (57 in 8 groups)
+### Tools (69 in 8 groups)
 
 | Group | Count | Examples |
 |-------|-------|----------|
-| Core | 13 | `list_scenes`, `start_recording`, `get_obs_status` |
+| Core | 25 | `list_scenes`, `start_recording`, `get_obs_status`, `toggle_virtual_cam`, `save_replay_buffer`, `toggle_studio_mode`, `trigger_hotkey_by_name` |
 | Sources | 3 | `list_sources`, `toggle_source_visibility` |
 | Audio | 4 | `toggle_input_mute`, `set_input_volume` |
 | Layout | 6 | `save_scene_preset`, `apply_scene_preset` |

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,8 +1,8 @@
 # agentic-obs Project Status
 
 **Status:** Active Development
-**Version:** 0.7.0
-**Updated:** 2025-12-19
+**Version:** 0.11.0
+**Updated:** 2025-12-21
 
 ---
 
@@ -23,7 +23,7 @@
 
 | Metric | Count |
 |--------|-------|
-| **MCP Tools** | 45 |
+| **MCP Tools** | 69 |
 | **MCP Resources** | 4 |
 | **MCP Prompts** | 13 |
 | **Claude Skills** | 4 |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This MCP server provides AI agents (like Claude) with programmatic control over 
 
 ## Features
 
-- **57 MCP Tools**: Comprehensive control over OBS Studio operations in 8 tool groups
+- **69 MCP Tools**: Comprehensive control over OBS Studio operations in 8 tool groups
 - **Scene Management**: List, switch, create, and remove OBS scenes
 - **Scene Presets**: Save and restore source visibility configurations
 - **Recording Control**: Start, stop, pause, resume, and monitor recording
@@ -264,7 +264,29 @@ Enable AI to create and manipulate OBS sources programmatically.
 | `set_transition_duration` | Set transition duration in milliseconds |
 | `trigger_transition` | Trigger studio mode transition (preview to program) |
 
-**Total: 57 tools in 8 groups** (Core, Sources, Audio, Layout, Visual, Design, Filters, Transitions) + Help
+### Virtual Cam & Replay Buffer (6 tools)
+
+| Tool | Description |
+|------|-------------|
+| `get_virtual_cam_status` | Check if virtual camera output is active |
+| `toggle_virtual_cam` | Toggle virtual camera on/off |
+| `get_replay_buffer_status` | Check if replay buffer is active |
+| `toggle_replay_buffer` | Toggle replay buffer on/off |
+| `save_replay_buffer` | Save current replay buffer to file |
+| `get_last_replay` | Get the file path of the last saved replay |
+
+### Studio Mode & Hotkeys (6 tools)
+
+| Tool | Description |
+|------|-------------|
+| `get_studio_mode_enabled` | Check if studio mode is enabled |
+| `toggle_studio_mode` | Enable or disable studio mode |
+| `get_preview_scene` | Get the current preview scene (studio mode) |
+| `set_preview_scene` | Set the preview scene (studio mode) |
+| `list_hotkeys` | List all available OBS hotkeys |
+| `trigger_hotkey_by_name` | Trigger a hotkey by name |
+
+**Total: 69 tools in 8 groups** (Core, Sources, Audio, Layout, Visual, Design, Filters, Transitions) + Help
 
 ## MCP Resources
 
@@ -315,7 +337,7 @@ agentic-obs/
 ├── main.go                 # Entry point (MCP server or TUI)
 ├── config/                 # Configuration management
 ├── internal/
-│   ├── mcp/               # MCP server implementation (57 tools)
+│   ├── mcp/               # MCP server implementation (69 tools)
 │   ├── obs/               # OBS WebSocket client
 │   ├── storage/           # SQLite persistence
 │   ├── http/              # HTTP server for screenshots and dashboard

--- a/design/ARCHITECTURE.md
+++ b/design/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document describes the system architecture of agentic-obs.
 
 ## System Overview
 
-agentic-obs is an MCP (Model Context Protocol) server that bridges AI assistants with OBS Studio. It provides 57 tools, 4 resource types, and 13 prompts for programmatic OBS control.
+agentic-obs is an MCP (Model Context Protocol) server that bridges AI assistants with OBS Studio. It provides 69 tools, 4 resource types, and 13 prompts for programmatic OBS control.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -162,13 +162,13 @@ Tracked features with unique identifiers for reference.
 | FB-14 | Brand & Design | Logo, favicon, ASCII banners, design system colors | Phase 9 |
 | FB-1 | Embedded Docs | Docs in HTTP/TUI via go:embed, goldmark/glamour rendering | Phase 9 |
 | FB-3 | MCP Elicitation | User confirmation for high-risk tools (streaming, delete) | Phase 9 |
+| FB-23 | Filters Tool Group | 7 tools for source filter management | Phase 10 |
+| FB-24 | Transitions | 5 tools for scene transition control | Phase 10 |
 
 ### Active Backlog
 
 | ID | Name | Priority | Complexity | Dependencies | Description |
 |----|------|----------|------------|--------------|-------------|
-| FB-23 | Filters Tool Group | High | Medium | - | 7 tools for source filter management |
-| FB-24 | Transitions | High | Low | - | 5 tools for scene transition control |
 | FB-20 | Automation Rules | High | Medium | - | Event-triggered actions and macros |
 | FB-25 | Virtual Cam & Replay | Medium | Low | - | 6 tools for virtual camera and replay buffer |
 | FB-26 | Studio Mode & Hotkeys | Medium | Low | - | 5 tools for studio mode and hotkey control |

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -164,14 +164,19 @@ Tracked features with unique identifiers for reference.
 | FB-3 | MCP Elicitation | User confirmation for high-risk tools (streaming, delete) | Phase 9 |
 | FB-23 | Filters Tool Group | 7 tools for source filter management | Phase 10 |
 | FB-24 | Transitions | 5 tools for scene transition control | Phase 10 |
+| FB-25 | Virtual Cam & Replay | 6 tools for virtual camera and replay buffer | Phase 11 |
+| FB-26 | Studio Mode & Hotkeys | 6 tools for studio mode and hotkey control | Phase 11 |
 
 ### Active Backlog
 
 | ID | Name | Priority | Complexity | Dependencies | Description |
 |----|------|----------|------------|--------------|-------------|
 | FB-20 | Automation Rules | High | Medium | - | Event-triggered actions and macros |
-| FB-25 | Virtual Cam & Replay | Medium | Low | - | 6 tools for virtual camera and replay buffer |
-| FB-26 | Studio Mode & Hotkeys | Medium | Low | - | 5 tools for studio mode and hotkey control |
+| FB-27 | Dynamic Tool Config | High | Medium | - | Runtime tool group enable/disable via MCP tools |
+| FB-28 | Skills Update | High | Low | FB-25, FB-26 ✅ | Update streaming-assistant with virtual cam, replay, studio mode |
+| FB-29 | New Prompts | Medium | Low | FB-25, FB-26 ✅ | Add virtual-cam-control, replay-management prompts |
+| FB-30 | Scene Designer Filters | Medium | Low | FB-23 ✅ | Add filter section to scene-designer skill |
+| FB-31 | Studio Mode Skill | Medium | Medium | FB-26 ✅ | New studio-mode-operator skill for preview/program workflow |
 | FB-19 | Release Automation | Medium | Low | FB-18 ✅ | GitHub Actions workflow for automated releases |
 | FB-4 | SDK Migration | Medium | Medium | - | Process for tracking go-sdk updates |
 | FB-21 | Additional Resources | Medium | Low-Med | - | Sources, filters, audio as MCP resources |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # MCP Tool Reference
 
-Comprehensive documentation for all 45 Model Context Protocol (MCP) tools provided by the agentic-obs server.
+Comprehensive documentation for all 69 Model Context Protocol (MCP) tools provided by the agentic-obs server.
 
 ## Table of Contents
 
@@ -60,6 +60,34 @@ Comprehensive documentation for all 45 Model Context Protocol (MCP) tools provid
   - [duplicate_source](#duplicate_source)
   - [remove_source](#remove_source)
   - [list_input_kinds](#list_input_kinds)
+- [Filters](#filters)
+  - [list_source_filters](#list_source_filters)
+  - [get_source_filter](#get_source_filter)
+  - [create_source_filter](#create_source_filter)
+  - [remove_source_filter](#remove_source_filter)
+  - [toggle_source_filter](#toggle_source_filter)
+  - [set_source_filter_settings](#set_source_filter_settings)
+  - [list_filter_kinds](#list_filter_kinds)
+- [Transitions](#transitions)
+  - [list_transitions](#list_transitions)
+  - [get_current_transition](#get_current_transition)
+  - [set_current_transition](#set_current_transition)
+  - [set_transition_duration](#set_transition_duration)
+  - [trigger_transition](#trigger_transition)
+- [Virtual Camera & Replay Buffer](#virtual-camera--replay-buffer)
+  - [get_virtual_cam_status](#get_virtual_cam_status)
+  - [toggle_virtual_cam](#toggle_virtual_cam)
+  - [get_replay_buffer_status](#get_replay_buffer_status)
+  - [toggle_replay_buffer](#toggle_replay_buffer)
+  - [save_replay_buffer](#save_replay_buffer)
+  - [get_last_replay](#get_last_replay)
+- [Studio Mode & Hotkeys](#studio-mode--hotkeys)
+  - [get_studio_mode_enabled](#get_studio_mode_enabled)
+  - [toggle_studio_mode](#toggle_studio_mode)
+  - [get_preview_scene](#get_preview_scene)
+  - [set_preview_scene](#set_preview_scene)
+  - [list_hotkeys](#list_hotkeys)
+  - [trigger_hotkey_by_name](#trigger_hotkey_by_name)
 - [Common Patterns](#common-patterns)
 - [Error Handling](#error-handling)
 
@@ -1912,6 +1940,312 @@ Scene Design tools enable AI assistants to programmatically create and manipulat
 - Discover what source types are available
 - Build dynamic source creation interfaces
 - Verify input kinds before creation
+
+---
+
+## Virtual Camera & Replay Buffer
+
+Tools for controlling OBS virtual camera output and replay buffer functionality.
+
+### get_virtual_cam_status
+
+**Purpose:** Check if the virtual camera output is currently active.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "active": true,
+  "message": "Virtual camera is active"
+}
+```
+
+**Use Cases:**
+- Check virtual camera state before toggling
+- Verify virtual camera is running for video calls
+- Monitor output status in dashboards
+
+---
+
+### toggle_virtual_cam
+
+**Purpose:** Toggle the virtual camera on or off.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "active": true,
+  "message": "Virtual camera is now active"
+}
+```
+
+**Use Cases:**
+- Start/stop virtual camera for video calls
+- Toggle as part of stream start/stop workflow
+- Enable OBS output for external applications
+
+---
+
+### get_replay_buffer_status
+
+**Purpose:** Check if the replay buffer is currently active.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "active": true,
+  "message": "Replay buffer is active"
+}
+```
+
+**Use Cases:**
+- Verify replay buffer is running before saving
+- Check buffer status during gameplay sessions
+- Monitor replay readiness
+
+---
+
+### toggle_replay_buffer
+
+**Purpose:** Start or stop the replay buffer.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "active": true,
+  "message": "Replay buffer is now active"
+}
+```
+
+**Use Cases:**
+- Enable replay buffer at stream start
+- Disable to save system resources
+- Part of gaming session workflow
+
+---
+
+### save_replay_buffer
+
+**Purpose:** Save the current replay buffer contents to disk.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "message": "Successfully saved replay buffer"
+}
+```
+
+**Prerequisites:**
+- Replay buffer must be active
+
+**Use Cases:**
+- Capture highlight moments during gameplay
+- Save instant replays on demand
+- Triggered by hotkeys or AI detection
+
+---
+
+### get_last_replay
+
+**Purpose:** Get the file path of the last saved replay buffer.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "saved_replay_path": "/recordings/replay-2024-01-15_14-30-00.mkv",
+  "message": "Last replay saved to: /recordings/replay-2024-01-15_14-30-00.mkv"
+}
+```
+
+**Use Cases:**
+- Retrieve path for post-processing
+- Verify replay was saved successfully
+- Build replay management workflows
+
+---
+
+## Studio Mode & Hotkeys
+
+Tools for controlling OBS studio mode (preview/program) and triggering hotkeys.
+
+### get_studio_mode_enabled
+
+**Purpose:** Check if studio mode is currently enabled.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "studio_mode_enabled": true,
+  "message": "Studio mode is enabled"
+}
+```
+
+**Use Cases:**
+- Check mode before preview operations
+- Verify workflow prerequisites
+- Monitor studio mode state
+
+---
+
+### toggle_studio_mode
+
+**Purpose:** Enable or disable studio mode.
+
+**Input:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `studio_mode_enabled` | boolean | Yes | True to enable, false to disable |
+
+**Example Request:**
+```json
+{
+  "studio_mode_enabled": true
+}
+```
+
+**Returns:**
+```json
+{
+  "studio_mode_enabled": true,
+  "message": "Studio mode is now enabled"
+}
+```
+
+**Use Cases:**
+- Enable for professional production workflows
+- Switch between simple and advanced modes
+- Prepare for multi-scene transitions
+
+---
+
+### get_preview_scene
+
+**Purpose:** Get the current preview scene in studio mode.
+
+**Input:** None
+
+**Prerequisites:**
+- Studio mode must be enabled
+
+**Returns:**
+```json
+{
+  "preview_scene": "Gaming",
+  "message": "Current preview scene: Gaming"
+}
+```
+
+**Use Cases:**
+- Check what scene is queued for transition
+- Verify preview before going live
+- Build preview/program UI
+
+---
+
+### set_preview_scene
+
+**Purpose:** Set the preview scene in studio mode.
+
+**Input:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scene_name` | string | Yes | Name of the scene to preview |
+
+**Example Request:**
+```json
+{
+  "scene_name": "BRB"
+}
+```
+
+**Prerequisites:**
+- Studio mode must be enabled
+- Scene must exist
+
+**Returns:**
+```json
+{
+  "preview_scene": "BRB",
+  "message": "Preview scene set to: BRB"
+}
+```
+
+**Use Cases:**
+- Queue next scene for transition
+- Prepare scene switches in advance
+- Build professional production workflows
+
+---
+
+### list_hotkeys
+
+**Purpose:** List all available OBS hotkey names.
+
+**Input:** None
+
+**Returns:**
+```json
+{
+  "hotkeys": [
+    "OBSBasic.StartRecording",
+    "OBSBasic.StopRecording",
+    "OBSBasic.StartStreaming",
+    "OBSBasic.StopStreaming",
+    "OBSBasic.Screenshot"
+  ],
+  "count": 5,
+  "message": "Found 5 available hotkeys"
+}
+```
+
+**Use Cases:**
+- Discover available automation triggers
+- Build hotkey reference documentation
+- Find specific hotkey names for triggering
+
+---
+
+### trigger_hotkey_by_name
+
+**Purpose:** Trigger an OBS hotkey by its name.
+
+**Input:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hotkey_name` | string | Yes | Name of the hotkey to trigger |
+
+**Example Request:**
+```json
+{
+  "hotkey_name": "OBSBasic.Screenshot"
+}
+```
+
+**Returns:**
+```json
+{
+  "hotkey_name": "OBSBasic.Screenshot",
+  "message": "Successfully triggered hotkey: OBSBasic.Screenshot"
+}
+```
+
+**Use Cases:**
+- Trigger screenshots programmatically
+- Automate custom OBS actions
+- Execute user-defined hotkey sequences
 
 ---
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -67,7 +67,7 @@ Comprehensive documentation for all 45 Model Context Protocol (MCP) tools provid
 
 ## Overview
 
-The agentic-obs MCP server provides 57 tools organized into 12 categories (8 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
+The agentic-obs MCP server provides 69 tools organized into 14 categories (8 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
 
 | Category | Tools | Description | Tool Group |
 |----------|-------|-------------|------------|
@@ -83,6 +83,8 @@ The agentic-obs MCP server provides 57 tools organized into 12 categories (8 too
 | Scene Design | 14 | Source creation and manipulation | Design |
 | Filters | 7 | Filter creation, toggle, settings | Filters |
 | Transitions | 5 | Transition control and configuration | Transitions |
+| Virtual Cam & Replay | 6 | Virtual camera and replay buffer control | Core |
+| Studio Mode & Hotkeys | 6 | Studio mode preview and hotkey triggers | Core |
 
 **General Prerequisites:**
 - OBS Studio 28+ running with WebSocket server enabled
@@ -2357,10 +2359,10 @@ Prompts use both tools and resources internally:
 
 ---
 
-**Document Version:** 5.0
-**Last Updated:** 2025-12-18
-**agentic-obs Version:** Phase 6.3 Complete
-**Total Tools:** 44 (6 tool groups)
-**Total Resources:** 3 types (scenes, screenshots, presets)
-**Total Prompts:** 10
+**Document Version:** 6.0
+**Last Updated:** 2025-12-21
+**agentic-obs Version:** Phase 11 Complete
+**Total Tools:** 69 (8 tool groups)
+**Total Resources:** 4 types (scenes, screenshots, screenshot-url, presets)
+**Total Prompts:** 13
 **Total API Endpoints:** 8

--- a/internal/docs/content/README.md
+++ b/internal/docs/content/README.md
@@ -264,7 +264,7 @@ Enable AI to create and manipulate OBS sources programmatically.
 | `set_transition_duration` | Set transition duration in milliseconds |
 | `trigger_transition` | Trigger studio mode transition (preview to program) |
 
-**Total: 57 tools in 8 groups** (Core, Sources, Audio, Layout, Visual, Design, Filters, Transitions) + Help
+**Total: 69 tools in 8 groups** (Core, Sources, Audio, Layout, Visual, Design, Filters, Transitions) + Help
 
 ## MCP Resources
 
@@ -315,7 +315,7 @@ agentic-obs/
 ├── main.go                 # Entry point (MCP server or TUI)
 ├── config/                 # Configuration management
 ├── internal/
-│   ├── mcp/               # MCP server implementation (57 tools)
+│   ├── mcp/               # MCP server implementation (69 tools)
 │   ├── obs/               # OBS WebSocket client
 │   ├── storage/           # SQLite persistence
 │   ├── http/              # HTTP server for screenshots and dashboard

--- a/internal/docs/content/TOOLS.md
+++ b/internal/docs/content/TOOLS.md
@@ -67,7 +67,7 @@ Comprehensive documentation for all 45 Model Context Protocol (MCP) tools provid
 
 ## Overview
 
-The agentic-obs MCP server provides 57 tools organized into 12 categories (8 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
+The agentic-obs MCP server provides 69 tools organized into 14 categories (8 tool groups + help) for comprehensive OBS Studio control. All tools communicate with OBS via WebSocket (default port 4455) and return structured JSON responses.
 
 | Category | Tools | Description | Tool Group |
 |----------|-------|-------------|------------|
@@ -83,6 +83,8 @@ The agentic-obs MCP server provides 57 tools organized into 12 categories (8 too
 | Scene Design | 14 | Source creation and manipulation | Design |
 | Filters | 7 | Filter creation, toggle, settings | Filters |
 | Transitions | 5 | Transition control and configuration | Transitions |
+| Virtual Cam & Replay | 6 | Virtual camera and replay buffer control | Core |
+| Studio Mode & Hotkeys | 6 | Studio mode preview and hotkey triggers | Core |
 
 **General Prerequisites:**
 - OBS Studio 28+ running with WebSocket server enabled
@@ -2357,10 +2359,10 @@ Prompts use both tools and resources internally:
 
 ---
 
-**Document Version:** 5.0
-**Last Updated:** 2025-12-18
-**agentic-obs Version:** Phase 6.3 Complete
-**Total Tools:** 44 (6 tool groups)
-**Total Resources:** 3 types (scenes, screenshots, presets)
-**Total Prompts:** 10
+**Document Version:** 6.0
+**Last Updated:** 2025-12-21
+**agentic-obs Version:** Phase 11 Complete
+**Total Tools:** 69 (8 tool groups)
+**Total Resources:** 4 types (scenes, screenshots, screenshot-url, presets)
+**Total Prompts:** 13
 **Total API Endpoints:** 8

--- a/internal/mcp/help_content.go
+++ b/internal/mcp/help_content.go
@@ -21,12 +21,12 @@ import "fmt"
 //
 // ============================================================================
 const (
-	HelpToolCount     = 57 // Total MCP tools (including help)
+	HelpToolCount     = 69 // Total MCP tools (including help)
 	HelpResourceCount = 4  // Resource types: scenes, screenshots, screenshot-url, presets
 	HelpPromptCount   = 13 // Workflow prompts
 
 	// Tool counts by category (should sum to HelpToolCount)
-	HelpCoreToolCount        = 13 // Scene management, recording, streaming, status
+	HelpCoreToolCount        = 25 // Scene management, recording, streaming, status, virtual cam, replay buffer, studio mode, hotkeys
 	HelpHelpToolCount        = 1  // The help tool itself
 	HelpSourcesToolCount     = 3  // Source management
 	HelpAudioToolCount       = 4  // Audio control

--- a/internal/mcp/help_test.go
+++ b/internal/mcp/help_test.go
@@ -443,7 +443,7 @@ func TestGetOverviewHelp(t *testing.T) {
 		assert.Contains(t, help, "What is agentic-obs")
 		assert.Contains(t, help, "Quick Start")
 		assert.Contains(t, help, "Key Features")
-		assert.Contains(t, help, "57 Tools")
+		assert.Contains(t, help, "69 Tools")
 		assert.Contains(t, help, "4 Resource Types")
 	})
 

--- a/internal/mcp/help_tools.go
+++ b/internal/mcp/help_tools.go
@@ -1308,6 +1308,228 @@ var toolHelpContent = map[string]string{
 **Use Case**: Manually trigger scene changes in studio mode workflow.
 
 **Error Handling**: Returns error if studio mode is not enabled.`,
+
+	// =========================================================================
+	// Virtual Camera Tools (FB-25)
+	// =========================================================================
+
+	"get_virtual_cam_status": `# get_virtual_cam_status
+
+**Category**: Core (Virtual Camera)
+
+**Description**: Check if the virtual camera is currently active.
+
+**Input**: None
+
+**Output**:
+- active: Boolean indicating if virtual camera is running
+- message: Human-readable status
+
+**Use Case**: Check virtual camera state before starting a video call or application that uses the OBS virtual camera.`,
+
+	"toggle_virtual_cam": `# toggle_virtual_cam
+
+**Category**: Core (Virtual Camera)
+
+**Description**: Start or stop the OBS virtual camera.
+
+**Input**: None
+
+**Output**:
+- active: Boolean indicating new virtual camera state
+- message: Human-readable result
+
+**Use Case**: Enable virtual camera for video conferencing apps (Zoom, Teams, etc.) that can use OBS as a camera source.
+
+**Note**: Virtual camera must be configured in OBS settings before use.`,
+
+	// =========================================================================
+	// Replay Buffer Tools (FB-25)
+	// =========================================================================
+
+	"get_replay_buffer_status": `# get_replay_buffer_status
+
+**Category**: Core (Replay Buffer)
+
+**Description**: Check if the replay buffer is currently active.
+
+**Input**: None
+
+**Output**:
+- active: Boolean indicating if replay buffer is running
+- message: Human-readable status
+
+**Use Case**: Check replay buffer state before attempting to save clips.`,
+
+	"toggle_replay_buffer": `# toggle_replay_buffer
+
+**Category**: Core (Replay Buffer)
+
+**Description**: Start or stop the replay buffer.
+
+**Input**: None
+
+**Output**:
+- active: Boolean indicating new replay buffer state
+- message: Human-readable result
+
+**Use Case**: Enable replay buffer to capture the last N seconds of gameplay for highlights.
+
+**Note**: Replay buffer duration and settings must be configured in OBS settings.`,
+
+	"save_replay_buffer": `# save_replay_buffer
+
+**Category**: Core (Replay Buffer)
+
+**Description**: Save the current replay buffer contents to disk.
+
+**Input**: None
+
+**Output**:
+- message: Success confirmation
+
+**Requirements**: Replay buffer must be active.
+
+**Use Case**: Capture a highlight moment - saves the last N seconds of recorded content.
+
+**Error Handling**: Returns error if replay buffer is not active.`,
+
+	"get_last_replay": `# get_last_replay
+
+**Category**: Core (Replay Buffer)
+
+**Description**: Get the file path of the last saved replay buffer.
+
+**Input**: None
+
+**Output**:
+- saved_replay_path: Full path to the saved replay file
+- message: Human-readable result
+
+**Use Case**: Retrieve the location of the most recent saved replay for review or sharing.`,
+
+	// =========================================================================
+	// Studio Mode Tools (FB-26)
+	// =========================================================================
+
+	"get_studio_mode_enabled": `# get_studio_mode_enabled
+
+**Category**: Core (Studio Mode)
+
+**Description**: Check if studio mode is currently enabled in OBS.
+
+**Input**: None
+
+**Output**:
+- studio_mode_enabled: Boolean indicating if studio mode is active
+- message: Human-readable status
+
+**Use Case**: Determine current mode before using preview scene features.
+
+**Note**: Studio mode provides separate preview and program outputs, allowing scene setup before going live.`,
+
+	"toggle_studio_mode": `# toggle_studio_mode
+
+**Category**: Core (Studio Mode)
+
+**Description**: Enable or disable studio mode in OBS.
+
+**Input**:
+- studio_mode_enabled (bool, required): True to enable, false to disable
+
+**Output**:
+- studio_mode_enabled: New studio mode state
+- message: Success confirmation
+
+**Example Input**:
+{
+  "studio_mode_enabled": true
+}
+
+**Use Case**: Enable studio mode for professional streaming workflows with preview capabilities.`,
+
+	"get_preview_scene": `# get_preview_scene
+
+**Category**: Core (Studio Mode)
+
+**Description**: Get the current preview scene in studio mode.
+
+**Input**: None
+
+**Output**:
+- preview_scene: Name of the current preview scene
+- message: Human-readable result
+
+**Requirements**: Studio mode must be enabled.
+
+**Error Handling**: Returns error if studio mode is not enabled.`,
+
+	"set_preview_scene": `# set_preview_scene
+
+**Category**: Core (Studio Mode)
+
+**Description**: Set the preview scene in studio mode.
+
+**Input**:
+- scene_name (string, required): Name of the scene to preview
+
+**Output**:
+- preview_scene: Name of the new preview scene
+- message: Success confirmation
+
+**Example Input**:
+{
+  "scene_name": "Starting Soon"
+}
+
+**Requirements**: Studio mode must be enabled.
+
+**Use Case**: Queue up the next scene without switching live output.
+
+**Error Handling**: Returns error if studio mode is not enabled or scene doesn't exist.`,
+
+	// =========================================================================
+	// Hotkey Tools (FB-26)
+	// =========================================================================
+
+	"trigger_hotkey_by_name": `# trigger_hotkey_by_name
+
+**Category**: Core (Hotkeys)
+
+**Description**: Trigger an OBS hotkey by its registered name.
+
+**Input**:
+- hotkey_name (string, required): Name of the hotkey to trigger
+
+**Output**:
+- hotkey_name: The triggered hotkey name
+- message: Success confirmation
+
+**Example Input**:
+{
+  "hotkey_name": "OBSBasic.StartRecording"
+}
+
+**Use Case**: Trigger OBS actions that have hotkey bindings, including custom plugin hotkeys.
+
+**Note**: Use list_hotkeys to discover available hotkey names.`,
+
+	"list_hotkeys": `# list_hotkeys
+
+**Category**: Core (Hotkeys)
+
+**Description**: List all available OBS hotkey names.
+
+**Input**: None
+
+**Output**:
+- hotkeys: Array of available hotkey names
+- count: Number of hotkeys found
+- message: Human-readable summary
+
+**Use Case**: Discover available hotkeys for automation or to find the correct name for trigger_hotkey_by_name.
+
+**Note**: Hotkey names follow the pattern "Context.Action" (e.g., "OBSBasic.StartRecording").`,
 }
 
 // GetToolHelpContent returns the help text for a specific tool, or empty if not found.

--- a/internal/mcp/interfaces.go
+++ b/internal/mcp/interfaces.go
@@ -91,12 +91,18 @@ type OBSClient interface {
 	TriggerStudioModeTransition() error
 
 	// Virtual camera operations
+	// Note: Start/Stop methods are kept internal for programmatic use cases.
+	// MCP tools expose only Toggle for simplicity - AI agents can check status
+	// first if they need idempotent behavior.
 	GetVirtualCamStatus() (*obs.VirtualCamStatus, error)
 	ToggleVirtualCam() (bool, error)
 	StartVirtualCam() error
 	StopVirtualCam() error
 
 	// Replay buffer operations
+	// Note: Start/Stop methods are kept internal for programmatic use cases.
+	// MCP tools expose only Toggle for simplicity - AI agents can check status
+	// first if they need idempotent behavior.
 	GetReplayBufferStatus() (*obs.ReplayBufferStatus, error)
 	ToggleReplayBuffer() (bool, error)
 	StartReplayBuffer() error

--- a/internal/mcp/interfaces.go
+++ b/internal/mcp/interfaces.go
@@ -90,6 +90,30 @@ type OBSClient interface {
 	SetCurrentSceneTransitionDuration(durationMs int) error
 	TriggerStudioModeTransition() error
 
+	// Virtual camera operations
+	GetVirtualCamStatus() (*obs.VirtualCamStatus, error)
+	ToggleVirtualCam() (bool, error)
+	StartVirtualCam() error
+	StopVirtualCam() error
+
+	// Replay buffer operations
+	GetReplayBufferStatus() (*obs.ReplayBufferStatus, error)
+	ToggleReplayBuffer() (bool, error)
+	StartReplayBuffer() error
+	StopReplayBuffer() error
+	SaveReplayBuffer() error
+	GetLastReplayBufferReplay() (string, error)
+
+	// Studio mode operations
+	GetStudioModeEnabled() (bool, error)
+	SetStudioModeEnabled(enabled bool) error
+	GetCurrentPreviewScene() (string, error)
+	SetCurrentPreviewScene(sceneName string) error
+
+	// Hotkey operations
+	TriggerHotkeyByName(hotkeyName string) error
+	GetHotkeyList() ([]string, error)
+
 	// Event handling
 	SetEventCallback(callback obs.EventCallback)
 }

--- a/internal/obs/commands.go
+++ b/internal/obs/commands.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 
 	"github.com/andreykaipov/goobs/api/requests/filters"
+	"github.com/andreykaipov/goobs/api/requests/general"
 	"github.com/andreykaipov/goobs/api/requests/inputs"
 	"github.com/andreykaipov/goobs/api/requests/sceneitems"
 	"github.com/andreykaipov/goobs/api/requests/scenes"
 	"github.com/andreykaipov/goobs/api/requests/sources"
 	"github.com/andreykaipov/goobs/api/requests/transitions"
+	"github.com/andreykaipov/goobs/api/requests/ui"
 	"github.com/andreykaipov/goobs/api/typedefs"
 )
 
@@ -1208,6 +1210,294 @@ func (c *Client) TriggerStudioModeTransition() error {
 			return fmt.Errorf("studio mode is not enabled. Enable studio mode in OBS to use this feature")
 		}
 		return fmt.Errorf("failed to trigger studio mode transition: %w", err)
+	}
+
+	return nil
+}
+
+// =============================================================================
+// Virtual Camera Types and Methods (FB-25)
+// =============================================================================
+
+// VirtualCamStatus represents the current virtual camera state.
+type VirtualCamStatus struct {
+	Active bool `json:"active"`
+}
+
+// GetVirtualCamStatus retrieves the current virtual camera status.
+func (c *Client) GetVirtualCamStatus() (*VirtualCamStatus, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Outputs.GetVirtualCamStatus()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get virtual camera status: %w", err)
+	}
+
+	return &VirtualCamStatus{
+		Active: resp.OutputActive,
+	}, nil
+}
+
+// ToggleVirtualCam toggles the virtual camera on or off.
+// Returns the new active state.
+func (c *Client) ToggleVirtualCam() (bool, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := client.Outputs.ToggleVirtualCam()
+	if err != nil {
+		return false, fmt.Errorf("failed to toggle virtual camera: %w", err)
+	}
+
+	return resp.OutputActive, nil
+}
+
+// =============================================================================
+// Replay Buffer Types and Methods (FB-25)
+// =============================================================================
+
+// ReplayBufferStatus represents the current replay buffer state.
+type ReplayBufferStatus struct {
+	Active bool `json:"active"`
+}
+
+// GetReplayBufferStatus retrieves the current replay buffer status.
+func (c *Client) GetReplayBufferStatus() (*ReplayBufferStatus, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Outputs.GetReplayBufferStatus()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get replay buffer status: %w", err)
+	}
+
+	return &ReplayBufferStatus{
+		Active: resp.OutputActive,
+	}, nil
+}
+
+// ToggleReplayBuffer toggles the replay buffer on or off.
+// Returns the new active state.
+func (c *Client) ToggleReplayBuffer() (bool, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := client.Outputs.ToggleReplayBuffer()
+	if err != nil {
+		return false, fmt.Errorf("failed to toggle replay buffer: %w", err)
+	}
+
+	return resp.OutputActive, nil
+}
+
+// SaveReplayBuffer saves the current replay buffer to disk.
+// The replay buffer must be active for this to succeed.
+func (c *Client) SaveReplayBuffer() error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Outputs.SaveReplayBuffer()
+	if err != nil {
+		return fmt.Errorf("failed to save replay buffer: %w. Replay buffer may not be active", err)
+	}
+
+	return nil
+}
+
+// GetLastReplayBufferReplay retrieves the path to the last saved replay.
+func (c *Client) GetLastReplayBufferReplay() (string, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Outputs.GetLastReplayBufferReplay()
+	if err != nil {
+		return "", fmt.Errorf("failed to get last replay path: %w", err)
+	}
+
+	return resp.SavedReplayPath, nil
+}
+
+// =============================================================================
+// Studio Mode Types and Methods (FB-26)
+// =============================================================================
+
+// GetStudioModeEnabled retrieves whether studio mode is enabled.
+func (c *Client) GetStudioModeEnabled() (bool, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := client.Ui.GetStudioModeEnabled()
+	if err != nil {
+		return false, fmt.Errorf("failed to get studio mode status: %w", err)
+	}
+
+	return resp.StudioModeEnabled, nil
+}
+
+// SetStudioModeEnabled enables or disables studio mode.
+func (c *Client) SetStudioModeEnabled(enabled bool) error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Ui.SetStudioModeEnabled(&ui.SetStudioModeEnabledParams{
+		StudioModeEnabled: &enabled,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set studio mode enabled=%v: %w", enabled, err)
+	}
+
+	return nil
+}
+
+// GetCurrentPreviewScene retrieves the current preview scene in studio mode.
+// Returns an error if studio mode is not enabled.
+func (c *Client) GetCurrentPreviewScene() (string, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Scenes.GetCurrentPreviewScene()
+	if err != nil {
+		if strings.Contains(err.Error(), "studio mode") {
+			return "", fmt.Errorf("studio mode is not enabled. Enable studio mode in OBS to use preview scenes")
+		}
+		return "", fmt.Errorf("failed to get current preview scene: %w", err)
+	}
+
+	return resp.CurrentPreviewSceneName, nil
+}
+
+// SetCurrentPreviewScene sets the current preview scene in studio mode.
+// Returns an error if studio mode is not enabled.
+func (c *Client) SetCurrentPreviewScene(sceneName string) error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Scenes.SetCurrentPreviewScene(&scenes.SetCurrentPreviewSceneParams{
+		SceneName: &sceneName,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "studio mode") {
+			return fmt.Errorf("studio mode is not enabled. Enable studio mode in OBS to use preview scenes")
+		}
+		return fmt.Errorf("failed to set preview scene to '%s': %w", sceneName, err)
+	}
+
+	return nil
+}
+
+// =============================================================================
+// Hotkey Methods (FB-26)
+// =============================================================================
+
+// TriggerHotkeyByName triggers a hotkey by its name.
+// Use GetHotkeyList() to discover available hotkey names.
+func (c *Client) TriggerHotkeyByName(hotkeyName string) error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.General.TriggerHotkeyByName(&general.TriggerHotkeyByNameParams{
+		HotkeyName: &hotkeyName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to trigger hotkey '%s': %w", hotkeyName, err)
+	}
+
+	return nil
+}
+
+// GetHotkeyList retrieves all available hotkey names.
+func (c *Client) GetHotkeyList() ([]string, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.General.GetHotkeyList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hotkey list: %w", err)
+	}
+
+	return resp.Hotkeys, nil
+}
+
+// StartVirtualCam starts the virtual camera.
+func (c *Client) StartVirtualCam() error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Outputs.StartVirtualCam()
+	if err != nil {
+		return fmt.Errorf("failed to start virtual camera: %w", err)
+	}
+
+	return nil
+}
+
+// StopVirtualCam stops the virtual camera.
+func (c *Client) StopVirtualCam() error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Outputs.StopVirtualCam()
+	if err != nil {
+		return fmt.Errorf("failed to stop virtual camera: %w", err)
+	}
+
+	return nil
+}
+
+// StartReplayBuffer starts the replay buffer.
+func (c *Client) StartReplayBuffer() error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Outputs.StartReplayBuffer()
+	if err != nil {
+		return fmt.Errorf("failed to start replay buffer: %w", err)
+	}
+
+	return nil
+}
+
+// StopReplayBuffer stops the replay buffer.
+func (c *Client) StopReplayBuffer() error {
+	client, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Outputs.StopReplayBuffer()
+	if err != nil {
+		return fmt.Errorf("failed to stop replay buffer: %w", err)
 	}
 
 	return nil

--- a/internal/obs/commands.go
+++ b/internal/obs/commands.go
@@ -1309,7 +1309,7 @@ func (c *Client) SaveReplayBuffer() error {
 
 	_, err = client.Outputs.SaveReplayBuffer()
 	if err != nil {
-		return fmt.Errorf("failed to save replay buffer: %w. Replay buffer may not be active", err)
+		return fmt.Errorf("failed to save replay buffer: %w", err)
 	}
 
 	return nil

--- a/scripts/verify-docs.sh
+++ b/scripts/verify-docs.sh
@@ -14,11 +14,11 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Current expected values - UPDATE THESE AFTER EACH PHASE
-EXPECTED_TOOLS=57
+EXPECTED_TOOLS=69
 EXPECTED_RESOURCES=4
 EXPECTED_PROMPTS=13
 EXPECTED_API_ENDPOINTS=8
-CURRENT_PHASE=10
+CURRENT_PHASE=11
 
 echo "=========================================="
 echo "Documentation Consistency Verification"


### PR DESCRIPTION
## Summary

This PR adds 12 new MCP tools across 2 feature groups, expanding the total from 57 to 69 tools.

### FB-25: Virtual Cam & Replay Buffer (6 tools)
- `get_virtual_cam_status` - Check if virtual camera is active
- `toggle_virtual_cam` - Toggle virtual camera on/off
- `get_replay_buffer_status` - Check if replay buffer is active
- `toggle_replay_buffer` - Toggle replay buffer on/off
- `save_replay_buffer` - Save current buffer to file
- `get_last_replay` - Get last saved replay file path

### FB-26: Studio Mode & Hotkeys (6 tools)
- `get_studio_mode_enabled` - Check if studio mode is enabled
- `toggle_studio_mode` - Enable/disable studio mode
- `get_preview_scene` - Get current preview scene
- `set_preview_scene` - Set preview scene (studio mode)
- `list_hotkeys` - List all OBS hotkey names
- `trigger_hotkey_by_name` - Trigger hotkey by name

## Changes

| File | Changes |
|------|---------|
| `internal/obs/commands.go` | 14 new OBS client methods |
| `internal/mcp/interfaces.go` | 16 interface methods added |
| `internal/mcp/testutil/mock_obs.go` | Full mock implementations |
| `internal/mcp/tools.go` | 12 tool handlers and registrations |
| `internal/mcp/help_tools.go` | Help entries for all new tools |
| Documentation | Updated all counts to reflect 69 tools |

## Test plan

- [x] All existing tests pass
- [x] `verify-docs.sh` passes with no issues
- [x] Build compiles successfully
- [x] Manual testing with OBS Studio (virtual cam, replay buffer, studio mode)
- [x] Verify hotkey triggering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)