### PR TITLE
fix: wrap list_sources result in object to match sibling handlers

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1158,8 +1158,12 @@ func (s *Server) handleListSources(ctx context.Context, request *mcpsdk.CallTool
 		return nil, nil, fmt.Errorf("failed to list sources: %w", err)
 	}
 
-	s.recordAction("list_sources", "List sources", nil, sources, true, time.Since(start))
-	return nil, sources, nil
+	result := map[string]interface{}{
+		"sources": sources,
+		"count":   len(sources),
+	}
+	s.recordAction("list_sources", "List sources", nil, result, true, time.Since(start))
+	return nil, result, nil
 }
 
 func (s *Server) handleToggleSourceVisibility(ctx context.Context, request *mcpsdk.CallToolRequest, input SourceVisibilityInput) (*mcpsdk.CallToolResult, any, error) {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -365,6 +365,14 @@ func TestHandleListSources(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
+
+		// Result must be a map (object), not a bare slice — MCP spec requires
+		// tool results to be JSON objects at the top level so clients can
+		// deserialize them without type ambiguity.
+		resultMap, ok := result.(map[string]interface{})
+		assert.True(t, ok, "result should be map[string]interface{}, got %T", result)
+		assert.Contains(t, resultMap, "sources")
+		assert.Contains(t, resultMap, "count")
 	})
 }
 


### PR DESCRIPTION
Fixes #24

`handleListSources` returned a bare `[]*typedefs.Input` slice directly, which the MCP Go SDK can't use to populate `structuredContent` — clients only saw the text representation, and some rejected the response because MCP expects tool results to be JSON objects at the top level.

Every other list-style handler in this file already wraps its result in a `map[string]interface{}{"<name>": ..., "count": ...}`. This brings `list_sources` in line with that pattern.

Also tightens `TestHandleListSources` to assert the map shape so the same oversight can't slip back in silently.

## Verification

- `go test ./...` — all tests pass, zero regressions
- Direct MCP stdio probe against a live OBS Studio (32.1.1) instance confirms the response now populates both `content` and `structuredContent` fields with `{count, sources}`
- Patched binary in daily use against my OBS rig; `list_sources` now returns cleanly to Claude Code

## Diff summary

- `internal/mcp/tools.go` — 6 lines changed in `handleListSources`
- `internal/mcp/tools_test.go` — 8 lines added to tighten `TestHandleListSources`