### PR TITLE
Sprint 0.5 #2 — FB-34: bump goobs v1.5.6 → v1.8.3 (obs-ws 5.7.3)

### DIFF
--- a/design/sprints/0.5-tangent-log.md
+++ b/design/sprints/0.5-tangent-log.md
@@ -21,6 +21,9 @@ See `../ROADMAP.md` → **Sprint Planning** for the sprint convention this docum
 | FB-4 | **Form & URL elicitation** (`FormElicitationCapabilities`, `URLElicitationCapabilities`) — beyond basic confirm; form inputs or URL-return flows | M | additive | URL-return is MCP Apps adjacent (launch-and-callback). Form elicitation could replace ad-hoc confirmations. |
 | FB-4 | **Richer completion context** (`CompleteContext`, `CompletionResultDetails`) — completions can receive arg-context and return metadata | S | additive | Could improve `completions.go` — currently flat. |
 | FB-4 | **`ToolChoice`** type for sampling — steer model to specific tool or mode | XS | additive | Only relevant once FB-4-sampling lands. |
+| FB-34 | **Deinterlace inputs API** (4 new requests: `Get/SetInputDeinterlaceMode`, `Get/SetInputDeinterlaceFieldOrder`) — capture-card / legacy-source users need this | S | additive | Fits cleanly into existing Sources tool group. Not urgent; streaming-focused. |
+| FB-34 | **Canvas CRUD beyond `GetCanvasList`** — upstream goobs v1.8.3 only exposes read; create/delete/rename may land in a later goobs release | S | needs-design | FB-42 (Sprint 1.0) starts read-only. Revisit when upstream ships write APIs. |
+| FB-34 | **`canvasUuid` parameter on scene requests** — `CreateScene`, `RemoveScene`, `SetSceneName`, `GetSceneList` all now accept optional canvas targeting | S | additive | Core to FB-42 multi-canvas; tracking here so it's remembered when FB-42 is scoped. |
 
 ### Column guide
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ironystock/agentic-obs
 go 1.25.5
 
 require (
-	github.com/andreykaipov/goobs v1.5.6
+	github.com/andreykaipov/goobs v1.8.3
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/alecthomas/chroma/v2 v2.14.0 h1:R3+wzpnUArGcQz7fCETQBzO5n9IMNi13iIs46
 github.com/alecthomas/chroma/v2 v2.14.0/go.mod h1:QolEbTfmUHIMVpBqxeDnNBj2uoeI4EbYP4i6n68SG4I=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/andreykaipov/goobs v1.5.6 h1:eIkEqYN99+2VJvmlY/56Ah60nkRKS6efMQvpM3oUgPQ=
-github.com/andreykaipov/goobs v1.5.6/go.mod h1:iSZP93FJ4d9X/U1x4DD4IyILLtig+vViqZWBGjLywcY=
+github.com/andreykaipov/goobs v1.8.3 h1:G/WWpXY0EHO4JJPEunifq7/JRCMmVrPRfF1yHV1MoH0=
+github.com/andreykaipov/goobs v1.8.3/go.mod h1:4Dl/G+rQXCywV85hdAKwsj8h352KsfILP+QUB1FvRSc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=


### PR DESCRIPTION
## Summary
- Bumps \`github.com/andreykaipov/goobs\` from v1.5.6 to v1.8.3 (protocol 5.5.x → 5.7.3)
- Zero API adaptation required; build + test suite green
- Unblocks FB-42 (Canvas support, Sprint 1.0) — \`GetCanvasList\` + Canvas events now available
- Surfaces \`RecordFileChanged\` (FB-36) and deprecated field audit (FB-35) as clean follow-ups

## Why land second
Pair with FB-4; after these two the rest of the sprint can land in any order.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\` — all packages green

## Deferred to tangent log
- Input deinterlace API (4 new requests)
- Canvas CRUD beyond \`GetCanvasList\` (upstream gap)
- \`canvasUuid\` scene-request parameter (note for FB-42 scoping)