### PR TITLE
Sprint 0.5 #3 — FB-35: migrate off deprecated CurrentPreviewSceneName

### DIFF
--- a/internal/obs/commands.go
+++ b/internal/obs/commands.go
@@ -1382,7 +1382,7 @@ func (c *Client) GetCurrentPreviewScene() (string, error) {
 		return "", fmt.Errorf("failed to get current preview scene: %w", err)
 	}
 
-	return resp.CurrentPreviewSceneName, nil
+	return resp.SceneName, nil
 }
 
 // SetCurrentPreviewScene sets the current preview scene in studio mode.


### PR DESCRIPTION
## Summary
One-line fix: \`internal/obs/commands.go:1385\` now uses \`resp.SceneName\` instead of the deprecated \`resp.CurrentPreviewSceneName\` from \`GetCurrentPreviewScene\`'s response.

## Audit findings (the ROADMAP description was broader than reality)
- \`GetCurrentPreviewScene\` response: \`CurrentPreviewSceneName\`/\`Uuid\` — **deprecated**, fixed
- \`GetCurrentProgramScene\` response: \`CurrentProgramSceneName\`/\`Uuid\` — not used in codebase, no migration needed
- \`GetSceneList\` response: \`CurrentProgramSceneName\` — **NOT deprecated** in v1.8.3, left as-is at \`commands.go:78\`

## Independent of FB-34
The \`SceneName\` field exists in goobs v1.5.6 too, so this PR branches off main directly.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\` — green