### PR TITLE
Sprint 0.5 #4 — FB-36: wire RecordFileChanged event

### DIFF
--- a/internal/automation/types.go
+++ b/internal/automation/types.go
@@ -52,6 +52,7 @@ const (
 	EventRecordingStopped        = "recording_stopped"
 	EventRecordingPaused         = "recording_paused"
 	EventRecordingResumed        = "recording_resumed"
+	EventRecordingFileChanged    = "recording_file_changed"
 	EventStreamingStarted        = "streaming_started"
 	EventStreamingStopped        = "streaming_stopped"
 	EventVirtualCamStarted       = "virtual_cam_started"
@@ -165,6 +166,7 @@ func SupportedEventTypes() []string {
 		EventRecordingStopped,
 		EventRecordingPaused,
 		EventRecordingResumed,
+		EventRecordingFileChanged,
 		EventStreamingStarted,
 		EventStreamingStopped,
 		EventVirtualCamStarted,

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1176,7 +1176,7 @@ func (s *Server) handleAutomationSetup(ctx context.Context, req *mcpsdk.GetPromp
    - Use create_automation_rule with trigger_type='event'
    - Supported events include:
      * 'stream_started', 'stream_stopped'
-     * 'recording_started', 'recording_stopped', 'recording_paused', 'recording_resumed'
+     * 'recording_started', 'recording_stopped', 'recording_paused', 'recording_resumed', 'recording_file_changed'
      * 'scene_changed'
      * 'source_visibility_changed'
      * 'input_mute_changed', 'input_volume_changed'

--- a/internal/obs/client.go
+++ b/internal/obs/client.go
@@ -53,6 +53,7 @@ type EventCallback interface {
 	OnRecordingStopped(outputPath string)
 	OnRecordingPaused()
 	OnRecordingResumed()
+	OnRecordingFileChanged(newOutputPath string)
 
 	// Streaming events
 	OnStreamingStarted()
@@ -334,6 +335,9 @@ func (c *Client) handleEvents() {
 			case e.OutputState == "OBS_WEBSOCKET_OUTPUT_RESUMED":
 				callback.OnRecordingResumed()
 			}
+
+		case *events.RecordFileChanged:
+			callback.OnRecordingFileChanged(e.NewOutputPath)
 
 		// Streaming events
 		case *events.StreamStateChanged:

--- a/internal/obs/events.go
+++ b/internal/obs/events.go
@@ -27,10 +27,11 @@ const (
 	EventTypeSceneChanged EventType = "scene_changed"
 
 	// Recording events
-	EventTypeRecordingStarted EventType = "recording_started"
-	EventTypeRecordingStopped EventType = "recording_stopped"
-	EventTypeRecordingPaused  EventType = "recording_paused"
-	EventTypeRecordingResumed EventType = "recording_resumed"
+	EventTypeRecordingStarted     EventType = "recording_started"
+	EventTypeRecordingStopped     EventType = "recording_stopped"
+	EventTypeRecordingPaused      EventType = "recording_paused"
+	EventTypeRecordingResumed     EventType = "recording_resumed"
+	EventTypeRecordingFileChanged EventType = "recording_file_changed"
 
 	// Streaming events
 	EventTypeStreamingStarted EventType = "streaming_started"
@@ -135,6 +136,17 @@ func (h *EventHandler) OnRecordingResumed() {
 	log.Printf("[OBS Event] Recording resumed")
 	if h.notificationFunc != nil {
 		h.notificationFunc(EventTypeRecordingResumed, map[string]interface{}{})
+	}
+}
+
+// OnRecordingFileChanged is called when the record output rotates to a new file
+// (e.g. OBS 30+ file splits).
+func (h *EventHandler) OnRecordingFileChanged(newOutputPath string) {
+	log.Printf("[OBS Event] Recording file changed: %s", newOutputPath)
+	if h.notificationFunc != nil {
+		h.notificationFunc(EventTypeRecordingFileChanged, map[string]interface{}{
+			"new_output_path": newOutputPath,
+		})
 	}
 }
 
@@ -267,6 +279,11 @@ func (l *EventLogger) OnRecordingResumed() {
 	log.Printf("[OBS Event Logger] Recording resumed")
 }
 
+// OnRecordingFileChanged logs recording file-rotation events.
+func (l *EventLogger) OnRecordingFileChanged(newOutputPath string) {
+	log.Printf("[OBS Event Logger] Recording file changed: %s", newOutputPath)
+}
+
 // OnStreamingStarted logs streaming start events.
 func (l *EventLogger) OnStreamingStarted() {
 	log.Printf("[OBS Event Logger] Streaming started")
@@ -362,6 +379,7 @@ type EventMetrics struct {
 	RecordingStoppedCount        int
 	RecordingPausedCount         int
 	RecordingResumedCount        int
+	RecordingFileChangedCount    int
 	StreamingStartedCount        int
 	StreamingStoppedCount        int
 	VirtualCamStartedCount       int
@@ -421,6 +439,11 @@ func (t *EventMetricsTracker) OnRecordingPaused() {
 // OnRecordingResumed increments the recording resumed counter.
 func (t *EventMetricsTracker) OnRecordingResumed() {
 	t.metrics.RecordingResumedCount++
+}
+
+// OnRecordingFileChanged increments the recording file-changed counter.
+func (t *EventMetricsTracker) OnRecordingFileChanged(newOutputPath string) {
+	t.metrics.RecordingFileChangedCount++
 }
 
 // OnStreamingStarted increments the streaming started counter.
@@ -542,6 +565,13 @@ func (c *CompositeEventCallback) OnRecordingPaused() {
 func (c *CompositeEventCallback) OnRecordingResumed() {
 	for _, callback := range c.callbacks {
 		callback.OnRecordingResumed()
+	}
+}
+
+// OnRecordingFileChanged dispatches to all registered callbacks.
+func (c *CompositeEventCallback) OnRecordingFileChanged(newOutputPath string) {
+	for _, callback := range c.callbacks {
+		callback.OnRecordingFileChanged(newOutputPath)
 	}
 }
 


### PR DESCRIPTION
## Summary
Bridges OBS 30+'s \`RecordFileChanged\` event (fires on recording file splits) end-to-end:
- \`obs.EventCallback\` gains \`OnRecordingFileChanged(newOutputPath)\`
- Dispatcher switch + \`EventHandler\`, \`EventLogger\`, \`EventMetricsTracker\`, \`CompositeEventCallback\` all implement it
- Automation engine accepts \`recording_file_changed\` as a rule trigger
- \`automation-setup\` prompt docs the new event type

## Two commits (layer-boundary split)
1. \`feat(obs): bridge RecordFileChanged event through EventCallback\`
2. \`feat(automation): accept recording_file_changed as rule trigger\`

## Use cases unlocked
- \"On file split, copy to backup dir\"
- \"On file split, post to webhook\"
- \"On file split, rotate audio track\"

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\` — green (event interfaces fully implemented; nothing relied on the old interface)