### PR TITLE
Sprint 0.5 #7 — FB-38: dropped_events_total counter

### DIFF
--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ironystock/agentic-obs/internal/storage"
@@ -25,6 +26,10 @@ type AutomationEngine struct {
 	eventChan chan EventPayload
 	wg        sync.WaitGroup // Tracks in-flight processEvents + executeRule goroutines
 	running   bool
+
+	// droppedEvents counts events discarded because eventChan was full.
+	// Accessed via sync/atomic so callers don't need to hold e.mu.
+	droppedEvents atomic.Uint64
 }
 
 // NewAutomationEngine creates a new automation engine.
@@ -119,8 +124,15 @@ func (e *AutomationEngine) HandleEvent(payload EventPayload) {
 	select {
 	case e.eventChan <- payload:
 	default:
-		log.Printf("[Automation] Event buffer full, dropping event: %s", payload.EventType)
+		dropped := e.droppedEvents.Add(1)
+		log.Printf("[Automation] Event buffer full, dropping event: %s (total dropped: %d)", payload.EventType, dropped)
 	}
+}
+
+// DroppedEventsTotal returns the cumulative number of events discarded due
+// to a full event buffer. Exposed for observability and tests.
+func (e *AutomationEngine) DroppedEventsTotal() uint64 {
+	return e.droppedEvents.Load()
 }
 
 // TriggerRule manually triggers a rule by ID.

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -478,6 +478,34 @@ func TestEngineOnErrorStop(t *testing.T) {
 	assert.False(t, execs[0].ActionResults[1].Success, "action #1 failed")
 }
 
+func TestEngineDroppedEventsCounter(t *testing.T) {
+	db, cleanup := testAutomationDB(t)
+	defer cleanup()
+
+	mock := NewMockOBSClient()
+	engine := NewAutomationEngine(db, mock)
+
+	// Don't start the engine — processEvents must NOT drain the channel
+	// so we can force a buffer overflow. eventChan is buffered to 100.
+
+	assert.Equal(t, uint64(0), engine.DroppedEventsTotal(),
+		"counter should start at zero")
+
+	// Fill the buffer exactly to capacity; none should drop yet.
+	for i := 0; i < 100; i++ {
+		engine.HandleEvent(EventPayload{EventType: EventSceneChanged})
+	}
+	assert.Equal(t, uint64(0), engine.DroppedEventsTotal(),
+		"no drops expected while buffer has room")
+
+	// Overflow by 5.
+	for i := 0; i < 5; i++ {
+		engine.HandleEvent(EventPayload{EventType: EventSceneChanged})
+	}
+	assert.Equal(t, uint64(5), engine.DroppedEventsTotal(),
+		"overflow events should increment counter")
+}
+
 func TestEngineMultipleActions(t *testing.T) {
 	db, cleanup := testAutomationDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
Adds an \`atomic.Uint64\` counter on \`AutomationEngine\` incremented every time \`HandleEvent\` drops an event because \`eventChan\` is full. Exposed via \`DroppedEventsTotal() uint64\`.

## Why
The 100-deep \`eventChan\` silently dropped events with only a log line. No way to detect sustained drop rates programmatically.

## Log line now includes running total:
\`[Automation] Event buffer full, dropping event: <type> (total dropped: <N>)\`

## Test plan
- [x] New \`TestEngineDroppedEventsCounter\`: fill buffer to 100 (no drops), overflow by 5, assert counter == 5
- [x] Full test suite green