### PR TITLE
Sprint 0.5 #8 — FB-41: scheduled retention sweep

### DIFF
--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -11,6 +11,13 @@ import (
 	"github.com/ironystock/agentic-obs/internal/storage"
 )
 
+// Default retention policy for execution history. Operators can override
+// at runtime via SetExecutionRetention / SetRetentionSweepInterval.
+const (
+	defaultExecutionRetention     = 30 * 24 * time.Hour // keep 30 days
+	defaultRetentionSweepInterval = 1 * time.Hour       // sweep hourly
+)
+
 // AutomationEngine manages automation rules and their execution.
 type AutomationEngine struct {
 	mu        sync.RWMutex
@@ -30,6 +37,10 @@ type AutomationEngine struct {
 	// droppedEvents counts events discarded because eventChan was full.
 	// Accessed via sync/atomic so callers don't need to hold e.mu.
 	droppedEvents atomic.Uint64
+
+	// Retention sweep configuration. Guarded by e.mu.
+	executionRetention     time.Duration
+	retentionSweepInterval time.Duration
 }
 
 // NewAutomationEngine creates a new automation engine.
@@ -37,13 +48,15 @@ func NewAutomationEngine(db *storage.DB, obsClient OBSClient) *AutomationEngine 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	engine := &AutomationEngine{
-		ctx:       ctx,
-		cancel:    cancel,
-		storage:   db,
-		executor:  NewExecutor(obsClient),
-		rules:     make(map[int64]*Rule),
-		cooldowns: make(map[int64]time.Time),
-		eventChan: make(chan EventPayload, 100),
+		ctx:                    ctx,
+		cancel:                 cancel,
+		storage:                db,
+		executor:               NewExecutor(obsClient),
+		rules:                  make(map[int64]*Rule),
+		cooldowns:              make(map[int64]time.Time),
+		eventChan:              make(chan EventPayload, 100),
+		executionRetention:     defaultExecutionRetention,
+		retentionSweepInterval: defaultRetentionSweepInterval,
 	}
 
 	return engine
@@ -80,9 +93,78 @@ func (e *AutomationEngine) Start() error {
 	e.wg.Add(1)
 	go e.processEvents()
 
+	// Start retention sweeper
+	e.wg.Add(1)
+	go e.retentionSweeper()
+
 	e.running = true
 	log.Printf("[Automation] Engine started with %d rules", len(e.rules))
 	return nil
+}
+
+// SetExecutionRetention overrides how long execution history is kept
+// before the background sweeper deletes it. Must be called before Start
+// or the next sweep tick will use the new value.
+func (e *AutomationEngine) SetExecutionRetention(d time.Duration) {
+	e.mu.Lock()
+	e.executionRetention = d
+	e.mu.Unlock()
+}
+
+// SetRetentionSweepInterval overrides how often the retention sweeper
+// runs. Must be called before Start; changes after Start do not
+// reschedule the current ticker.
+func (e *AutomationEngine) SetRetentionSweepInterval(d time.Duration) {
+	e.mu.Lock()
+	e.retentionSweepInterval = d
+	e.mu.Unlock()
+}
+
+// retentionSweeper periodically purges old rule_executions records.
+func (e *AutomationEngine) retentionSweeper() {
+	defer e.wg.Done()
+
+	e.mu.RLock()
+	interval := e.retentionSweepInterval
+	e.mu.RUnlock()
+	if interval <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-e.ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := e.RunRetentionSweep(); err != nil && e.ctx.Err() == nil {
+				log.Printf("[Automation] Retention sweep failed: %v", err)
+			}
+		}
+	}
+}
+
+// RunRetentionSweep executes a single retention pass immediately and
+// returns the number of rows removed. Exposed for tests and for
+// operators who want to purge on demand.
+func (e *AutomationEngine) RunRetentionSweep() (int64, error) {
+	e.mu.RLock()
+	retention := e.executionRetention
+	e.mu.RUnlock()
+	if retention <= 0 {
+		return 0, nil
+	}
+
+	deleted, err := e.storage.ClearOldRuleExecutions(e.ctx, retention)
+	if err != nil {
+		return 0, err
+	}
+	if deleted > 0 {
+		log.Printf("[Automation] Retention sweep: removed %d executions older than %s", deleted, retention)
+	}
+	return deleted, nil
 }
 
 // Stop gracefully shuts down the engine. Waits for all in-flight

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -506,6 +506,77 @@ func TestEngineDroppedEventsCounter(t *testing.T) {
 		"overflow events should increment counter")
 }
 
+// TestEngineRetentionSweep verifies the background retention sweeper
+// deletes execution history older than the configured retention window.
+func TestEngineRetentionSweep(t *testing.T) {
+	db, cleanup := testAutomationDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed: one 48h-old execution (will be pruned) and one current
+	// execution (will be kept). Retention = 24h.
+	rule := storage.AutomationRule{
+		Name:          "retention-test",
+		Enabled:       true,
+		TriggerType:   TriggerTypeManual,
+		TriggerConfig: map[string]interface{}{},
+		Actions:       []storage.RuleAction{{Type: ActionTypeStartRecording}},
+	}
+	ruleID, err := db.CreateAutomationRule(ctx, rule)
+	require.NoError(t, err)
+
+	old := storage.RuleExecution{
+		RuleID:      ruleID,
+		RuleName:    rule.Name,
+		TriggerType: TriggerTypeManual,
+		StartedAt:   time.Now().Add(-48 * time.Hour),
+		Status:      storage.ExecutionStatusCompleted,
+	}
+	_, err = db.CreateRuleExecution(ctx, old)
+	require.NoError(t, err)
+
+	recent := storage.RuleExecution{
+		RuleID:      ruleID,
+		RuleName:    rule.Name,
+		TriggerType: TriggerTypeManual,
+		StartedAt:   time.Now(),
+		Status:      storage.ExecutionStatusCompleted,
+	}
+	_, err = db.CreateRuleExecution(ctx, recent)
+	require.NoError(t, err)
+
+	mock := NewMockOBSClient()
+	engine := NewAutomationEngine(db, mock)
+	engine.SetExecutionRetention(24 * time.Hour)
+
+	// Run a one-shot sweep without starting the engine loops.
+	deleted, err := engine.RunRetentionSweep()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted, "expected the 48h-old execution to be removed")
+
+	remaining, err := db.GetRuleExecutions(ctx, ruleID, 10)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1, "recent execution should be retained")
+}
+
+// TestEngineRetentionSweeperStartsOnStart verifies the sweeper goroutine
+// is launched by Start and shut down by Stop without deadlocking.
+func TestEngineRetentionSweeperStartsOnStart(t *testing.T) {
+	db, cleanup := testAutomationDB(t)
+	defer cleanup()
+
+	mock := NewMockOBSClient()
+	engine := NewAutomationEngine(db, mock)
+	// Aggressive sweep tempo so the goroutine runs at least once.
+	engine.SetRetentionSweepInterval(20 * time.Millisecond)
+	engine.SetExecutionRetention(1 * time.Millisecond)
+
+	require.NoError(t, engine.Start())
+	time.Sleep(60 * time.Millisecond) // let sweeper tick
+	engine.Stop()                     // must not hang
+	assert.False(t, engine.IsRunning())
+}
+
 func TestEngineMultipleActions(t *testing.T) {
 	db, cleanup := testAutomationDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
Background goroutine periodically calls \`ClearOldRuleExecutions\` to prevent \`rule_executions\` table bloat.

## Defaults
- 30-day retention (\`defaultExecutionRetention\`)
- 1-hour sweep cadence (\`defaultRetentionSweepInterval\`)

## New public API
- \`SetExecutionRetention(d)\` — override retention window
- \`SetRetentionSweepInterval(d)\` — override sweep cadence
- \`RunRetentionSweep() (int64, error)\` — one-shot immediate sweep (ops + tests)

## Lifecycle
Sweeper goroutine registered on \`engine.wg\`; \`Stop()\` cancels ctx and waits. Context-canceled errors during shutdown are suppressed.

## Test plan
- [x] \`TestEngineRetentionSweep\` — seed 48h-old + current, retention=24h, assert only the old record is deleted
- [x] \`TestEngineRetentionSweeperStartsOnStart\` — aggressive tempo (20ms interval, 1ms retention), asserts Stop doesn't hang
- [x] Full test suite green