### PR TITLE
Sprint 0.5 #9 — FB-39: concurrency stress tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,11 @@ test-coverage:
 	@echo "Coverage report: coverage.html"
 
 # Run tests with race detector
+# Requires CGO_ENABLED=1 and a C compiler (gcc/MinGW on Windows, xcode-select
+# on macOS). CI runs this on ubuntu-latest where gcc is pre-installed.
 .PHONY: test-race
 test-race:
-	$(GOTEST) -v -race ./...
+	CGO_ENABLED=1 $(GOTEST) -v -race ./...
 
 # Run go vet
 .PHONY: vet

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -577,6 +577,148 @@ func TestEngineRetentionSweeperStartsOnStart(t *testing.T) {
 	assert.False(t, engine.IsRunning())
 }
 
+// TestEngineConcurrentDispatch stresses the cooldown map and rule cache
+// under parallel HandleEvent calls. On the default (non-CGO) lane this
+// detects correctness bugs (duplicate fires, lost events, deadlocks); on
+// the race lane (make test-race on a CGO-enabled host, or CI ubuntu-latest)
+// the race detector catches unsynchronized accesses to e.rules / e.cooldowns.
+func TestEngineConcurrentDispatch(t *testing.T) {
+	db, cleanup := testAutomationDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// 5 rules, all watching the same event, each with different cooldowns.
+	for i := 0; i < 5; i++ {
+		rule := storage.AutomationRule{
+			Name:        "concurrent-" + string(rune('a'+i)),
+			Enabled:     true,
+			TriggerType: TriggerTypeEvent,
+			TriggerConfig: map[string]interface{}{
+				"event_type": EventSceneChanged,
+			},
+			Actions:    []storage.RuleAction{{Type: ActionTypeStartRecording}},
+			CooldownMs: 200, // 200ms cooldown on every rule
+		}
+		_, err := db.CreateAutomationRule(ctx, rule)
+		require.NoError(t, err)
+	}
+
+	mock := NewMockOBSClient()
+	engine := NewAutomationEngine(db, mock)
+	require.NoError(t, engine.Start())
+
+	// Fire 200 events from 20 goroutines. With a 200ms cooldown and the
+	// whole test taking <100ms, we expect each rule to fire exactly once,
+	// so exactly 5 actions total despite ~200 dispatches.
+	const goroutines = 20
+	const eventsPerGoroutine = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < eventsPerGoroutine; j++ {
+				engine.HandleEvent(EventPayload{
+					EventType: EventSceneChanged,
+					Data:      map[string]interface{}{},
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Drain: wait for all in-flight executeRule goroutines to complete.
+	time.Sleep(200 * time.Millisecond)
+
+	// Correctness guarantees we check even without -race:
+	//   (a) at least one rule fires per rule — the dispatcher isn't starved
+	//   (b) no panic / unrecovered map-write occurred (test would've crashed)
+	//   (c) engine.Stop() drains the wg without deadlocking
+	//
+	// We intentionally do NOT assert an exact upper bound on actions here;
+	// that guarantee belongs to the cooldown contract tested by
+	// TestEngineCooldown. This test's job is concurrency survival.
+	actions := mock.GetActions()
+	assert.GreaterOrEqual(t, len(actions), 5,
+		"every rule should fire at least once under a 200-event burst")
+
+	// Stop must not hang under load.
+	done := make(chan struct{})
+	go func() { engine.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("engine.Stop() did not return within 2s — likely deadlock")
+	}
+}
+
+// TestEngineConcurrentReloadAndDispatch exercises ReloadRules racing
+// against dispatchEvent. Both touch the e.rules map under e.mu; on the
+// race lane this asserts the locking discipline is correct, and on the
+// default lane it smoke-tests that no panics or deadlocks surface.
+func TestEngineConcurrentReloadAndDispatch(t *testing.T) {
+	db, cleanup := testAutomationDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	rule := storage.AutomationRule{
+		Name:          "reload-dispatch-race",
+		Enabled:       true,
+		TriggerType:   TriggerTypeEvent,
+		TriggerConfig: map[string]interface{}{"event_type": EventSceneChanged},
+		Actions:       []storage.RuleAction{{Type: ActionTypeStartRecording}},
+	}
+	_, err := db.CreateAutomationRule(ctx, rule)
+	require.NoError(t, err)
+
+	mock := NewMockOBSClient()
+	engine := NewAutomationEngine(db, mock)
+	require.NoError(t, engine.Start())
+	defer engine.Stop()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Dispatcher goroutine: fires events continuously.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				engine.HandleEvent(EventPayload{
+					EventType: EventSceneChanged,
+					Data:      map[string]interface{}{},
+				})
+			}
+		}
+	}()
+
+	// Reloader goroutine: reloads rules continuously.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = engine.ReloadRules()
+			}
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	// If we got here without panicking or deadlocking, the lock discipline
+	// is at least consistent under this workload.
+	assert.True(t, engine.IsRunning())
+}
+
 func TestEngineMultipleActions(t *testing.T) {
 	db, cleanup := testAutomationDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
Two stress tests exercising the automation engine's shared mutable state (\`e.rules\`, \`e.cooldowns\`) under parallel load.

- \`TestEngineConcurrentDispatch\`: 20 goroutines × 10 events = 200 events against 5 cooldown-gated rules. Asserts all rules fire at least once and \`Stop()\` drains the wg without deadlocking.
- \`TestEngineConcurrentReloadAndDispatch\`: one goroutine dispatches continuously while another reloads rules. Asserts no panic or deadlock.

## Makefile
\`test-race\` target now explicitly sets \`CGO_ENABLED=1\` and documents the C-compiler requirement. CI (ubuntu-latest) already runs \`-race\`; this just makes the local \`make test-race\` invocation actually work on CGO-enabled dev machines.

## Assertion-loosening rationale
Assertions are deliberately weak (\"at least one fire per rule\") rather than exact. Exact-count contract belongs to \`TestEngineCooldown\` under FB-37. **After FB-37 merges**, consider tightening to \`assert.Len(actions, 5)\` — currently loose so this PR lands independently of #5.

## Test plan
- [x] \`go test ./internal/automation/... -run TestEngineConcurrent -count=3\` — green
- [x] CI race lane (ubuntu) exercises the locks