### PR TITLE
Sprint 0.5 #12 — FB-33: skills modernization (folds FB-30, FB-31)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -69,9 +69,10 @@ Claude should recognize and describe the agentic-obs skills.
 - Virtual camera control for video calls
 - Replay buffer management for highlight capture
 - Studio mode preview/program transitions
-- Hotkey automation for quick actions
+- Hotkey-based quick actions
+- Automation rules for event-triggered and scheduled workflows
 
-**Tools used**: `get_obs_status`, `list_scenes`, `list_sources`, `toggle_source_visibility`, `get_input_mute`, `get_input_volume`, `list_scene_presets`, `apply_scene_preset`, `start_streaming`, `stop_streaming`, `get_streaming_status`, `get_virtual_cam_status`, `toggle_virtual_cam`, `get_replay_buffer_status`, `toggle_replay_buffer`, `save_replay_buffer`, `get_last_replay`, `get_studio_mode_enabled`, `toggle_studio_mode`, `get_preview_scene`, `set_preview_scene`, `list_hotkeys`, `trigger_hotkey_by_name`
+**Tools used**: `get_obs_status`, `list_scenes`, `list_sources`, `toggle_source_visibility`, `get_input_mute`, `get_input_volume`, `list_scene_presets`, `apply_scene_preset`, `start_streaming`, `stop_streaming`, `get_streaming_status`, `get_virtual_cam_status`, `toggle_virtual_cam`, `get_replay_buffer_status`, `toggle_replay_buffer`, `save_replay_buffer`, `get_last_replay`, `get_studio_mode_enabled`, `toggle_studio_mode`, `get_preview_scene`, `set_preview_scene`, `list_hotkeys`, `trigger_hotkey_by_name`, `list_automation_rules`, `create_automation_rule`, `update_automation_rule`, `enable_automation_rule`, `disable_automation_rule`, `trigger_automation_rule`
 
 **Best for**: Users who need AI assistance during live streaming sessions, including pre-stream setup, real-time adjustments, highlight capture, virtual camera for video calls, and post-stream cleanup.
 
@@ -89,8 +90,9 @@ Claude should recognize and describe the agentic-obs skills.
 - Precise source positioning, scaling, and rotation
 - Multi-source layout composition
 - Crop and visibility control
+- Source filters: chroma key, color correction, sharpen, noise suppression
 
-**Tools used**: All 14 Design tools including `create_text_source`, `create_image_source`, `create_color_source`, `create_browser_source`, `set_source_transform`, `get_source_transform`, `set_source_crop`, `remove_source_from_scene`, `duplicate_source`, `set_source_index`, `set_source_blend_mode`, `set_source_locked`, `set_source_visible`, `get_scene_item_id`
+**Tools used**: All 14 Design tools plus the 7 Filters tools — `create_text_source`, `create_image_source`, `create_color_source`, `create_browser_source`, `set_source_transform`, `get_source_transform`, `set_source_crop`, `remove_source_from_scene`, `duplicate_source`, `set_source_index`, `set_source_blend_mode`, `set_source_locked`, `set_source_visible`, `get_scene_item_id`, `list_source_filters`, `get_source_filter`, `create_source_filter`, `remove_source_filter`, `toggle_source_filter`, `set_source_filter_settings`, `list_filter_kinds`
 
 **Best for**: Users designing stream layouts, creating overlays, positioning sources, or building complex visual compositions.
 
@@ -132,6 +134,30 @@ Claude should recognize and describe the agentic-obs skills.
 
 ---
 
+### 5. Studio Mode Operator (`studio-mode-operator`)
+
+**When to use**: Two-scene preview/program workflow — staging scenes
+privately before putting them live, rehearsing transitions, or directing
+a broadcast with a separation between what's being prepared and what's
+on air.
+
+**Key capabilities**:
+- Enabling and exiting studio mode
+- Preview-side scene staging (`set_preview_scene`)
+- Transition type selection (cut/fade/slide) and duration tuning
+- Promoting preview to program via `trigger_transition`
+- Emergency direct-cut guidance (when to bypass preview)
+- Reconnect-safe state inspection
+
+**Tools used**: `get_studio_mode_enabled`, `toggle_studio_mode`, `get_preview_scene`, `set_preview_scene`, `list_scenes`, `get_current_scene`, `set_current_scene`, `list_transitions`, `get_current_transition`, `set_current_transition`, `trigger_transition`
+
+**Best for**: Broadcast operators, multi-segment shows, and anyone who
+needs to stage scene changes privately before committing them to the
+live output. Use `streaming-assistant` for whole-session workflows that
+only incidentally touch studio mode.
+
+---
+
 ## Skill Selection Guide
 
 Claude will automatically select the appropriate skill based on your request. However, you can explicitly invoke a skill:
@@ -147,7 +173,11 @@ Claude will automatically select the appropriate skill based on your request. Ho
 | "Switch to my gaming preset" | `preset-manager` |
 | "Start the virtual camera for my video call" | `streaming-assistant` |
 | "Save that moment as a highlight" | `streaming-assistant` |
-| "Preview the next scene before switching" | `streaming-assistant` |
+| "Preview the next scene before switching" | `studio-mode-operator` |
+| "Auto-mute mic when I switch to BRB" | `streaming-assistant` (automation) |
+| "Add chroma key to my webcam" | `scene-designer` (filters) |
+| "Enable studio mode and rehearse the transition" | `studio-mode-operator` |
+| "Fade to the Intermission scene over 800ms" | `studio-mode-operator` |
 
 ## Using Skills Effectively
 
@@ -269,6 +299,7 @@ For issues with skills or agentic-obs:
 
 ---
 
-**Last Updated**: 2025-12-21
-**agentic-obs Version**: 0.12.0
-**Skills Version**: 1.1.0
+**Last Updated**: 2026-04-18
+**agentic-obs Version**: 0.13.0+ (Sprint 0.5 — Upstream Alignment)
+**Skills Version**: 1.2.0 — adds `studio-mode-operator`, filter coverage
+in `scene-designer`, automation coverage in `streaming-assistant`

--- a/skills/scene-designer/SKILL.md
+++ b/skills/scene-designer/SKILL.md
@@ -72,6 +72,23 @@ As the **scene-designer**, your role is to:
 ### Utility (1 tool)
 - `list_input_kinds` - List available source types in OBS
 
+### Source Filters (7 tools)
+Filters modify the visual or audio output of a source without changing
+the source itself. Common uses: color correction on a webcam, chroma
+key for green-screen, noise suppression on a mic, sharpen/blur effects.
+
+- `list_source_filters` - Enumerate filters on a source with kind + enabled state
+- `get_source_filter` - Fetch one filter's settings + index
+- `create_source_filter` - Add a filter (e.g. `color_filter_v2`, `chroma_key_filter_v2`)
+- `remove_source_filter` - Delete a filter from a source
+- `toggle_source_filter` - Enable/disable without removing
+- `set_source_filter_settings` - Tune existing filter params
+- `list_filter_kinds` - Discover every filter kind OBS supports on this machine
+
+**Filter ordering matters** — filters apply top-to-bottom in the list.
+Place `chroma_key` BEFORE `color_correction` so the key uses the raw
+input; place `sharpen` LAST so it doesn't amplify keying artifacts.
+
 ## Canvas Understanding
 
 OBS uses a coordinate system with:
@@ -198,6 +215,57 @@ User: "Add my Streamlabs alerts"
 5. Confirm:
    - Report: "Alert box added at top center"
 ```
+
+### Adding a Chroma Key (Green Screen) to a Webcam
+
+```
+1. Pick the source:
+   - Use list_sources to find the webcam source name
+
+2. Survey existing filters:
+   - list_source_filters for that source so you know the current order
+
+3. Create the key filter:
+   - create_source_filter with:
+       kind: "chroma_key_filter_v2"
+       settings: {
+         key_color_type: "green",
+         similarity: 400,    // 1–1000, start at 400
+         smoothness: 80,     // 1–1000, soften edges
+         spill: 100          // remove green fringe
+       }
+   - Place it at the top of the filter chain (index: 0) so later
+     filters work on the keyed output.
+
+4. Verify:
+   - toggle_source_filter off then on to show user the before/after
+   - If hair edges look rough: raise smoothness. If background bleeds
+     through: raise similarity. If green tint remains: raise spill.
+```
+
+### Color-Correcting a Webcam
+
+```
+1. list_source_filters to check for an existing color filter
+2. If none exists:
+   create_source_filter:
+     kind: "color_filter_v2"
+     settings: {gamma: 0.0, contrast: 0.0, brightness: 0.0, saturation: 0.0, hue_shift: 0.0}
+3. Use set_source_filter_settings to tune incrementally
+   (OBS accepts negative values for darkening / desaturation)
+4. Order: chroma_key -> color_filter -> sharpen/blur
+```
+
+### Troubleshooting Filters
+
+- **Filter has no visible effect** - Check it's enabled (`toggle_source_filter`)
+  and that its index is below any filter that resets the pixel data
+  (e.g. `luma_key` after `chroma_key` will undo the key).
+- **Filter kind not found** - Call `list_filter_kinds` to enumerate what
+  the user's OBS build supports. Plugin-provided filters vary by install.
+- **Audio filters silent** - They live on the *input* source, not on a
+  scene item. Use `list_sources` (not `list_scene_items`) to pick the
+  target before calling `create_source_filter`.
 
 ## Layout Design Patterns
 

--- a/skills/streaming-assistant/SKILL.md
+++ b/skills/streaming-assistant/SKILL.md
@@ -121,6 +121,26 @@ As the **streaming-assistant**, your role is to:
 - `list_hotkeys` - List available OBS hotkey names
 - `trigger_hotkey_by_name` - Trigger any OBS hotkey
 
+### Automation Rules
+- `list_automation_rules` - Enumerate all configured rules (enabled + disabled)
+- `get_automation_rule` - Fetch a single rule's trigger, actions, cooldown
+- `create_automation_rule` - Define an event- or schedule-triggered rule
+- `update_automation_rule` - Change triggers, actions, cooldown, priority
+- `delete_automation_rule` - Remove a rule
+- `enable_automation_rule` / `disable_automation_rule` - Toggle without deleting
+- `trigger_automation_rule` - Fire a rule manually (operator override)
+
+Supported event triggers include `stream_started`, `stream_stopped`,
+`recording_started/stopped/paused/resumed/file_changed`, `scene_changed`,
+`source_visibility_changed`, `input_mute_changed`, `virtual_cam_started/stopped`,
+`replay_buffer_saved`, `transition_started`, `studio_mode_changed`.
+Schedule triggers accept cron expressions.
+
+Actions available: `set_scene`, `toggle_mute`/`set_mute`, `set_volume`,
+`toggle_visibility`/`set_visibility`, `start/stop/pause/resume_recording`,
+`start/stop_streaming`, virtual-cam + replay-buffer controls,
+`trigger_hotkey`, `trigger_transition`, `set_preview_scene`, and `delay`.
+
 ## Pre-Stream Workflow
 
 When users request pre-stream setup, follow this systematic checklist:
@@ -304,6 +324,48 @@ User: "Trigger the screenshot hotkey"
 2. Use trigger_hotkey_by_name with "OBSBasic.Screenshot"
 3. Confirm: "Screenshot captured"
 ```
+
+### Automation Rules Mid-Stream
+```
+User: "Auto-mute my mic whenever I switch to the BRB scene"
+1. Use create_automation_rule with:
+   - trigger_type: "event"
+   - trigger_config: {event_type: "scene_changed",
+                      event_filter: {scene_name: "BRB"}}
+   - actions: [{type: "set_mute",
+                parameters: {input_name: "Microphone", muted: true}}]
+   - cooldown_ms: 1000  (avoid double-fires during rapid switches)
+2. Confirm the rule is enabled; mention it will fire on the next scene change
+
+User: "Pause recording every hour for file rotation"
+1. Use create_automation_rule with:
+   - trigger_type: "schedule"
+   - trigger_config: {schedule: "0 * * * *"}  (hourly at :00)
+   - actions: [
+       {type: "pause_recording"},
+       {type: "delay", parameters: {ms: 500}},
+       {type: "resume_recording"}
+     ]
+2. Remind user the scheduler uses the machine's local time
+
+User: "What automation rules do I have running?"
+1. Use list_automation_rules
+2. Group by enabled/disabled; report trigger type and last_run timestamp
+3. Call out any rules without a cooldown on event triggers (can over-fire)
+
+User: "Stop the auto-mute rule but keep its config"
+1. Use list_automation_rules to find the rule ID by name
+2. Use disable_automation_rule with that ID
+3. Confirm the rule remains defined but will not fire until re-enabled
+```
+
+**Troubleshooting automation:**
+- If a rule isn't firing, check `enabled=true`, confirm `event_type` exactly
+  matches the canonical string, and inspect recent entries with
+  `get_automation_rule` → look at `last_run` and `run_count`.
+- Sustained event burst drop rate surfaces in server logs as
+  `[Automation] Event buffer full, dropping event: <type>`. If you see
+  these, widen cooldown windows on the over-eager rules.
 
 ## Post-Stream Workflow
 

--- a/skills/studio-mode-operator/SKILL.md
+++ b/skills/studio-mode-operator/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: studio-mode-operator
+description: Activate this skill when users need help with OBS Studio Mode's preview/program workflow — staging scene changes privately, rehearsing transitions, and committing them to the live output. Triggers include "enable studio mode", "preview the next scene", "rehearse a transition", "promote preview to program", "what's queued on preview", or "switch my transition to fade". This skill focuses on the two-scene discipline (program = what viewers see, preview = what's being prepared) rather than general streaming setup.
+---
+
+# Studio Mode Operator
+
+Expert guidance for OBS Studio Mode, the two-scene preview/program workflow
+used by broadcast operators to stage changes before putting them on air.
+
+## When to Use This Skill
+
+Activate **studio-mode-operator** when users request help with:
+
+- **Entering and exiting studio mode**
+  - "Enable studio mode"
+  - "Turn on preview/program"
+  - "I want to rehearse transitions"
+  - "Disable studio mode, I'm done directing"
+
+- **Preview-side staging**
+  - "What's on preview right now?"
+  - "Queue up the Gaming scene on preview"
+  - "Preview the BRB scene without switching"
+
+- **Transitions between preview and program**
+  - "Cut to preview" (immediate)
+  - "Fade to preview over 500ms"
+  - "What transition is active?"
+  - "Change my default transition to Slide"
+
+- **Transition rehearsal**
+  - "Show me how the transition will look before I fire it"
+  - "Practice the segment change"
+
+- **Troubleshooting studio mode**
+  - "The transition button isn't doing anything"
+  - "My preview scene reverted"
+
+Prefer `streaming-assistant` for end-to-end stream sessions that only
+incidentally touch studio mode; reach for this skill when the user's
+primary focus is the preview/program discipline itself.
+
+## Core Responsibilities
+
+1. **Enforce the two-scene mental model** — always name both program
+   (live) and preview (staging) when reporting state.
+2. **Never clobber program without asking.** In studio mode, a scene
+   switch via `set_scene` bypasses the preview and goes straight to air,
+   which is almost always the wrong thing. Route through preview +
+   transition instead.
+3. **Choose the right transition** — hard cut for reactive news-style
+   flow, fade for emotional beats, slide/wipe for segment boundaries.
+4. **Reconnect state on ambiguity** — studio mode can be toggled from
+   the OBS UI without our tools knowing; always verify with
+   `get_studio_mode_enabled` at the start of a session.
+
+## Available Tools
+
+### Studio Mode Control
+- `get_studio_mode_enabled` - Check whether studio mode is active
+- `toggle_studio_mode` - Enable/disable studio mode
+
+### Preview Scene
+- `get_preview_scene` - Get the name of the scene currently on preview
+- `set_preview_scene` - Put a scene on preview (no-op on program)
+
+### Program (Live) Scene
+- `get_current_scene` / `list_scenes` - Inspect program and available scenes
+- `set_current_scene` - Puts a scene DIRECTLY on program; avoid in
+  studio mode unless the user explicitly wants to skip the transition
+
+### Transitions
+- `list_transitions` - Available transition types (Cut, Fade, Slide, etc.)
+- `get_current_transition` - Which transition is default
+- `set_current_transition` - Change the default transition + duration
+- `trigger_transition` - Execute the current transition (preview -> program)
+
+### Contextual
+- `get_obs_status` - Sanity-check OBS is connected
+
+## Core Workflow: Preview → Program
+
+This is the canonical loop studio-mode operators run on every scene change:
+
+```
+1. User indicates what they want live ("Switch to Gaming")
+
+2. Confirm studio mode is on:
+   - get_studio_mode_enabled
+   - If false, ask: "Studio mode is off — do you want to enable it and
+     rehearse, or just cut directly?"
+
+3. Stage on preview:
+   - set_preview_scene with the target scene
+   - get_preview_scene to confirm
+   - Report: "Gaming is queued on preview; program still shows BRB"
+
+4. Confirm the transition type is appropriate:
+   - get_current_transition
+   - If the user said "fade", set_current_transition to "Fade" first
+
+5. Commit to program:
+   - trigger_transition
+   - The preview scene becomes the new program; program becomes preview
+
+6. Verify:
+   - get_current_scene (now Gaming)
+   - get_preview_scene (now BRB — swapped)
+```
+
+## Transition Selection Guide
+
+| Situation | Transition | Notes |
+|---|---|---|
+| Breaking news / reactive cut | `Cut` | Zero-duration, most responsive |
+| Segment boundary, same tone | `Fade` | 300-500ms feels natural |
+| Topic change, different tone | `Fade` + longer (800ms) | Gives viewer a mental beat |
+| Structured show transitions | `Slide` / `Swipe` | Signals segment change strongly |
+| Intentional "jarring" moment | `Stinger` | Requires a configured stinger media source |
+
+Always prefer the transition the user specifies by name. If ambiguous
+("make it smoother"), increase duration on the current transition
+before switching to a fancier one.
+
+## Example Workflows
+
+### Example 1: Simple Scene Change via Preview
+
+```
+User: "Go to Gaming"
+
+1. get_studio_mode_enabled → true
+2. list_scenes → confirm "Gaming" exists
+3. set_preview_scene("Gaming")
+4. Report: "Gaming queued on preview. Trigger transition when ready?"
+5. User confirms
+6. trigger_transition
+7. Report: "On air with Gaming"
+```
+
+### Example 2: Enabling Studio Mode Mid-Session
+
+```
+User: "Enable studio mode and stage the BRB scene"
+
+1. get_studio_mode_enabled → false
+2. toggle_studio_mode
+3. get_studio_mode_enabled → true (verify)
+4. At this point preview mirrors program — inform the user
+5. set_preview_scene("BRB")
+6. Report: "Studio mode on. BRB on preview, Gaming still on program.
+   Ready to transition."
+```
+
+### Example 3: Rehearsing a Fade
+
+```
+User: "Show me how a 1-second fade to Intermission looks before I commit"
+
+1. get_current_transition → {name: "Cut", duration: 0}
+2. set_current_transition("Fade", duration_ms: 1000)
+3. set_preview_scene("Intermission")
+4. Report: "Fade set to 1s, Intermission on preview. Hit trigger to
+   rehearse — the actual program won't change until you do."
+5. User says: "OK, now do it"
+6. trigger_transition
+7. Confirm new program
+```
+
+### Example 4: Emergency Direct Cut
+
+```
+User: "Just cut to Emergency scene NOW — something on-camera"
+
+1. Skip preview staging (user signalled urgency)
+2. set_current_scene("Emergency")
+3. Report: "Emergency scene LIVE. Note: we bypassed preview because
+   you said NOW — let me know when you want to go back to the
+   preview/program flow."
+```
+
+This is the ONE time `set_current_scene` is preferable in studio mode.
+Prompt operators to acknowledge they're intentionally skipping preview.
+
+## Common Pitfalls
+
+### Program and Preview Appear Identical
+- **Cause**: Studio mode was just enabled, or a transition just fired.
+  Preview mirrors program at that moment.
+- **Fix**: Normal state. `set_preview_scene` to diverge them.
+
+### `trigger_transition` Does Nothing
+- **Cause**: Studio mode is disabled — there's no preview to promote.
+- **Fix**: `get_studio_mode_enabled`. If false, either enable it or
+  use `set_current_scene` for direct cuts.
+
+### Transition Is Instant Despite Setting Duration
+- **Cause**: The current transition is `Cut`, which ignores duration.
+- **Fix**: `set_current_transition` to Fade/Slide/etc., THEN duration
+  applies.
+
+### Scene Disappeared from Preview After OBS Restart
+- **Cause**: Preview state is not persisted across OBS restarts.
+- **Fix**: Re-stage with `set_preview_scene` after reconnecting.
+
+## Best Practices
+
+1. **Name both scenes in every status report.** "Program: Gaming,
+   Preview: BRB" is unambiguous; "On Gaming" is not.
+2. **Confirm transition type before firing on novel scene changes.**
+   The transition set last night may not match today's intent.
+3. **Use long fades sparingly on live content.** 500ms is the sweet
+   spot — longer makes pacing drag unless it's deliberate.
+4. **For scheduled transitions (start-of-stream bumper, etc.)**,
+   prefer automation rules (see `streaming-assistant`) over manual
+   trigger_transition calls.
+
+## Integration with Other Skills
+
+- **streaming-assistant** - Handles the whole stream lifecycle; defer
+  to it for pre-stream checklists. This skill owns only the
+  preview/program loop once streaming is live.
+- **preset-manager** - Scene presets are compatible with studio mode;
+  apply on preview, then trigger_transition to put the preset on air.
+- **scene-designer** - Layout changes happen to scenes. When you
+  modify program while studio mode is on, preview and program can
+  diverge in content — re-run the transition to converge them.
+
+## OBS Version Notes
+
+- **`get_preview_scene` / `set_preview_scene`** require studio mode to
+  be enabled. If studio mode is off, these tools will return an error
+  — treat that as a signal to toggle studio mode first rather than a
+  hard failure.
+- **OBS 30 multi-canvas (Sprint 1.0 / FB-42):** studio mode applies to
+  the main canvas only. Additional canvases (vertical output, etc.)
+  don't participate in the preview/program flow; they're driven
+  directly.


### PR DESCRIPTION
## Summary
Three doc commits:
1. **FB-30** — \`scene-designer/SKILL.md\` gains full coverage of the 7 Filters tools: chroma key workflow (with similarity/smoothness/spill starting values), color correction, filter ordering rule, 3-symptom troubleshooting.
2. **FB-31** — New \`studio-mode-operator/SKILL.md\` (239 lines) dedicated to the preview/program workflow. Includes transition selection guide, 4 workflow examples, common pitfalls, and an OBS 30 multi-canvas note for Sprint 1.0.
3. **FB-33 core** — \`streaming-assistant/SKILL.md\` gets automation-rules coverage (was zero before). Lists all 9 automation tools, supported event triggers (including \`recording_file_changed\` from FB-36), action types, and 4 mid-stream workflow examples. \`skills/README.md\` registers the new skill and bumps Skills Version to 1.2.0.

## Review angle
Pure documentation — build/tests are unchanged. Review for accuracy of tool names/behavior and for whether the new examples match how you'd actually use the tools.

## Note on prompt references
\`automation-setup\` prompt's event list was updated on the FB-36 branch (not this one) to include \`recording_file_changed\`. If FB-36 hasn't merged yet, the line is still accurate against the FB-36 branch's state — no conflict expected.

## Test plan
- [x] \`go build ./...\`
- [ ] Spot-review each of the 3 updated skill files