### PR TITLE
docs(sprint-0.5): close sprint — promote tangent candidates to FB-45..FB-50

### DIFF
--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -156,8 +156,10 @@ FB item numbers and sprint numbers are orthogonal: an **FB item** is a single tr
 
 | Sprint | Focus | Status | Contains |
 |--------|-------|--------|----------|
-| **0.5** | Upstream Alignment & FB-20 Follow-ups | In progress | FB-4, FB-32..FB-41, FB-43, FB-44 (FB-30, FB-31 folded into FB-33) |
-| **1.0** | Canvas & Multi-Output | Candidate (blocked on 0.5) | FB-42 |
+| **0.5** | Upstream Alignment & FB-20 Follow-ups | ✅ Closed 2026-04-18 | FB-4, FB-32..FB-41, FB-43, FB-44 (FB-30, FB-31 folded into FB-33) |
+| **1.0** | Canvas & Multi-Output | Candidate | FB-42 |
+| **1.5** | *(unscheduled — candidates: FB-47, FB-48, FB-49, FB-50)* | Proposed | — |
+| **2.0** | *(unscheduled — candidate anchor: FB-45 sampling)* | Proposed | — |
 
 ### Sprint 0.5 — Upstream Alignment & FB-20 Follow-ups
 
@@ -219,7 +221,7 @@ Ordered by sprint, then priority. Items marked `—` in the Sprint column are un
 |----|------|----------|------------|--------|--------------|-------------|
 | FB-4 | SDK Migration (MCP Go SDK bump) | High | Medium | **0.5** | - | Bump `github.com/modelcontextprotocol/go-sdk` past v1.1.0; absorb API changes; surface MCP Apps / sampling / annotations opportunities |
 | FB-34 | goobs + obs-websocket 5.5 → 5.7 bump | High | Medium | **0.5** | - | Bump goobs v1.5.6 → v1.8.3 (protocol 5.5 → 5.7); absorb API changes; unblocks FB-42 |
-| FB-32 | MCP Apps Port | High | Medium-High | **0.5** | FB-4 | Port the mcpui-go work (FB-15 ✅) to the new MCP Apps spec at `apps.extensions.modelcontextprotocol.io`; shape depends on FB-4 discoveries |
+| FB-32 | MCP Apps Port | High | Medium-High | **0.5** *(ADR shipped; impl deferred)* | FB-4 ✅ | Port the mcpui-go work (FB-15 ✅) to the new MCP Apps spec at `apps.extensions.modelcontextprotocol.io`; shape captured in [ADR-008](decisions/008-mcp-apps-port.md). Stage 3 absorbs Form/URL elicitation (`FormElicitationCapabilities`/`URLElicitationCapabilities`) folded from the tangent log. |
 | FB-33 | Skills Modernization Sweep | Medium | Medium | **0.5** | FB-20 ✅, FB-27 ✅ | Audit all 4 skills against 81 tools + 14 prompts; add automation coverage to `streaming-assistant`; folds FB-30 and FB-31 |
 | FB-35 | Deprecated field audit (`currentProgram*` / `currentPreview*`) | Medium | Low | **0.5** | FB-34 | Migrate off scene-response fields flagged for removal in obs-websocket protocol |
 | FB-36 | `RecordFileChanged` event wiring | Low | Low | **0.5** | FB-34 | Bridge OBS 30+ file-split event into the automation engine's event bridge |
@@ -230,7 +232,13 @@ Ordered by sprint, then priority. Items marked `—` in the Sprint column are un
 | FB-41 | Automation execution retention | Medium | Low-Med | **0.5** | FB-20 ✅ | Scheduled sweep via `ClearOldRuleExecutions` to prevent DB bloat over time |
 | FB-43 | Charm v1 majors (bubbles + glamour) | Low-Med | Low-Med | **0.5** | - | Bump `charmbracelet/bubbles` v0.21→v1.0 and `charmbracelet/glamour` v0.10→v1.0 together; both hit TUI + docs rendering layer; absorb v1 API breaks |
 | FB-44 | modernc/sqlite catch-up | Medium | Low-Med | **0.5** | - | Bump `modernc.org/sqlite` v1.40→v1.49 (9 minor versions); verify storage layer + driver pool behavior unchanged via existing `internal/storage` tests |
-| FB-42 | Canvas Support (OBS 30+) | High | Medium-High | **1.0** | FB-34 | New tool group for OBS 30 multi-canvas: `GetCanvasList`, `obs://canvas/*` resource, `Canvas*` event bridge |
+| FB-42 | Canvas Support (OBS 30+) | High | Medium-High | **1.0** | FB-34 ✅ | New tool group for OBS 30 multi-canvas: `GetCanvasList`, `obs://canvas/*` resource, `Canvas*` event bridge. Absorbs the `canvasUuid` scene-request parameter added in obs-websocket 5.7 (noted during FB-34 bump). |
+| FB-45 | MCP Sampling | Medium-High | Medium | **2.0** *(proposed)* | FB-4 ✅ | Server-initiated LLM calls via `CreateMessageParams`/`ModelPreferences`/`ModelHint`. Negotiate `SamplingCapabilities` at init. Candidate callers: screenshot narration, automation rule-name suggestion, scene-cluster naming. Scope includes the `ToolChoice` hint type folded from tangent log. |
+| FB-46 | Sampling tool-call loop | Low | Large | — | FB-45 | `CreateMessageWithToolsParams`/`CreateMessageWithToolsResult` — sampling can recursively invoke our own tools. High-value (server-side mini-agents over OBS state) but real scope risk; write an ADR before implementing. |
+| FB-47 | MCP Annotations on tools | Medium | Low | **1.5** *(proposed)* | FB-4 ✅ | Apply the `Annotations` struct (priority/audience/`readOnly`/`destructive`/`idempotent`) to tool definitions for safer client-side gating. Cross-check with existing elicitation layer to avoid redundant confirmations. |
+| FB-48 | MCP Icons on tools/prompts/resources | Low-Med | Small-Medium | **1.5** *(proposed)* | FB-4 ✅, FB-14 ✅ | Declare `Icon`/`IconTheme` on tool/prompt/resource definitions with light/dark variants. Reuses the FB-14 logo/favicon assets. UX polish for MCP Apps clients that render icons. |
+| FB-49 | Richer completion context | Low | Small | — | FB-4 ✅ | Use `CompleteContext`/`CompletionResultDetails` to pass argument context to `completions.go` and return metadata. Current implementation is flat; this would enable smarter autocomplete. |
+| FB-50 | Deinterlace inputs API | Low | Small | — | FB-34 ✅ | Wrap the 4 new obs-websocket 5.7 requests (`Get/SetInputDeinterlaceMode`, `Get/SetInputDeinterlaceFieldOrder`) as Sources-group tools. Streaming/capture-card users only. |
 | FB-30 | Scene Designer Filters | Medium | Low | 0.5 (via FB-33) | FB-23 ✅ | Add filter section to `scene-designer` skill |
 | FB-31 | Studio Mode Skill | Medium | Medium | 0.5 (via FB-33) | FB-26 ✅ | New `studio-mode-operator` skill for preview/program workflow |
 | FB-29 | New Prompts (virtual-cam-control, replay-management) | Medium | Low | — | FB-25 ✅, FB-26 ✅ | Add virtual-cam-control, replay-management prompts |

--- a/design/sprints/0.5-tangent-log.md
+++ b/design/sprints/0.5-tangent-log.md
@@ -2,6 +2,8 @@
 
 Captures feature opportunities surfaced during Sprint 0.5 dep bumps **without letting them balloon the sprint**. Candidates here are deliberately *not* acted on during 0.5 — they get promoted to FB-numbered items at sprint close for scheduling in a future sprint.
 
+**Status: closed 2026-04-18.** See the **Disposition** column below for what each candidate became. This file is now a historical record of the sprint's discoveries; do not add new items here — the next N.5 sprint will have its own tangent log.
+
 See `../ROADMAP.md` → **Sprint Planning** for the sprint convention this document supports.
 
 ## Rules
@@ -12,18 +14,18 @@ See `../ROADMAP.md` → **Sprint Planning** for the sprint convention this docum
 
 ## Candidates
 
-| Surfaced during | Scope (one-line) | Effort | Shape | Notes |
-|-----------------|------------------|--------|-------|-------|
-| FB-4 | **Sampling** (`CreateMessageParams`, `SamplingMessageV2`, `ModelPreferences`, `ModelHint`) — server-initiated LLM calls for e.g. "describe this screenshot" or "name this scene cluster" | M | needs-design | New `SamplingCapabilities` with `Context` and `Tools` sub-capabilities; negotiate at init. Candidate callers: screenshot narration, automation rule name suggestion. |
-| FB-4 | **Tool-call loop in sampling** (`CreateMessageWithToolsParams` / `CreateMessageWithToolsResult`) — sampling can recursively use our own tools | L | needs-design | Would let the server run mini-agents over OBS state. High-value but scope risk. |
-| FB-4 | **Annotations** (`Annotations` struct) — per-item hints (priority, audience) on tools/resources/prompts | S | additive | Potentially enables "destructive" / "readOnly" / "idempotent" hints for safer tool gating. Cross-check with existing elicitation layer. |
-| FB-4 | **Icons** (`Icon`, `IconTheme`) — tools/prompts/resources can declare icons; supports light/dark themes | S-M | additive | Pairs with FB-14 (Brand & Design ✅) — we already have a logo + favicon. Good UX win for MCP Apps clients that render icons. |
-| FB-4 | **Form & URL elicitation** (`FormElicitationCapabilities`, `URLElicitationCapabilities`) — beyond basic confirm; form inputs or URL-return flows | M | additive | URL-return is MCP Apps adjacent (launch-and-callback). Form elicitation could replace ad-hoc confirmations. |
-| FB-4 | **Richer completion context** (`CompleteContext`, `CompletionResultDetails`) — completions can receive arg-context and return metadata | S | additive | Could improve `completions.go` — currently flat. |
-| FB-4 | **`ToolChoice`** type for sampling — steer model to specific tool or mode | XS | additive | Only relevant once FB-4-sampling lands. |
-| FB-34 | **Deinterlace inputs API** (4 new requests: `Get/SetInputDeinterlaceMode`, `Get/SetInputDeinterlaceFieldOrder`) — capture-card / legacy-source users need this | S | additive | Fits cleanly into existing Sources tool group. Not urgent; streaming-focused. |
-| FB-34 | **Canvas CRUD beyond `GetCanvasList`** — upstream goobs v1.8.3 only exposes read; create/delete/rename may land in a later goobs release | S | needs-design | FB-42 (Sprint 1.0) starts read-only. Revisit when upstream ships write APIs. |
-| FB-34 | **`canvasUuid` parameter on scene requests** — `CreateScene`, `RemoveScene`, `SetSceneName`, `GetSceneList` all now accept optional canvas targeting | S | additive | Core to FB-42 multi-canvas; tracking here so it's remembered when FB-42 is scoped. |
+| Surfaced during | Scope (one-line) | Effort | Shape | Disposition |
+|-----------------|------------------|--------|-------|-------------|
+| FB-4 | **Sampling** (`CreateMessageParams`, `SamplingMessageV2`, `ModelPreferences`, `ModelHint`) — server-initiated LLM calls for e.g. "describe this screenshot" or "name this scene cluster" | M | needs-design | → **FB-45** (Sprint 2.0 candidate anchor) |
+| FB-4 | **Tool-call loop in sampling** (`CreateMessageWithToolsParams` / `CreateMessageWithToolsResult`) — sampling can recursively use our own tools | L | needs-design | → **FB-46** (blocked on FB-45; unscheduled) |
+| FB-4 | **Annotations** (`Annotations` struct) — per-item hints (priority, audience) on tools/resources/prompts | S | additive | → **FB-47** (Sprint 1.5 candidate) |
+| FB-4 | **Icons** (`Icon`, `IconTheme`) — tools/prompts/resources can declare icons; supports light/dark themes | S-M | additive | → **FB-48** (Sprint 1.5 candidate) |
+| FB-4 | **Form & URL elicitation** (`FormElicitationCapabilities`, `URLElicitationCapabilities`) — beyond basic confirm; form inputs or URL-return flows | M | additive | **folded into FB-32** (MCP Apps port, ADR-008 Stage 3) |
+| FB-4 | **Richer completion context** (`CompleteContext`, `CompletionResultDetails`) — completions can receive arg-context and return metadata | S | additive | → **FB-49** (unscheduled) |
+| FB-4 | **`ToolChoice`** type for sampling — steer model to specific tool or mode | XS | additive | **folded into FB-45** (sampling implementation decides surface) |
+| FB-34 | **Deinterlace inputs API** (4 new requests: `Get/SetInputDeinterlaceMode`, `Get/SetInputDeinterlaceFieldOrder`) — capture-card / legacy-source users need this | S | additive | → **FB-50** (unscheduled) |
+| FB-34 | **Canvas CRUD beyond `GetCanvasList`** — upstream goobs v1.8.3 only exposes read; create/delete/rename may land in a later goobs release | S | needs-design | **deferred** — see Rejected/Deferred below |
+| FB-34 | **`canvasUuid` parameter on scene requests** — `CreateScene`, `RemoveScene`, `SetSceneName`, `GetSceneList` all now accept optional canvas targeting | S | additive | **subsumed by FB-42** — now part of FB-42's scope |
 
 ### Column guide
 
@@ -31,10 +33,11 @@ See `../ROADMAP.md` → **Sprint Planning** for the sprint convention this docum
 - **Scope** — one-line description; link to upstream release notes or spec if relevant
 - **Effort** — T-shirt size: `XS` / `S` / `M` / `L` / `XL`
 - **Shape** — one of: `additive` (no existing callers affected), `breaking` (migration needed), `needs-design` (requires scope/naming decision before implementation)
-- **Notes** — free-form (blockers, open questions, who flagged it)
+- **Disposition** — outcome at sprint close: promoted to a new FB, folded into an existing FB, or deferred (see below)
 
 ## Rejected / Deferred
 
 Items that were considered and consciously dropped. Keep a one-line rationale so we don't re-surface them during the next upstream sweep.
 
-*(empty)*
+- **Canvas CRUD beyond `GetCanvasList`** (FB-34) — **deferred, blocked on upstream goobs.** goobs v1.8.3 only exposes `GetCanvasList`; there are no create/delete/rename/update APIs to wrap. Nothing to build until upstream ships write APIs. Revisit on the next goobs bump (N.5 sprint after 1.0).
+- **`canvasUuid` parameter on scene requests** (FB-34) — **subsumed by FB-42.** The optional `canvasUuid` argument on `CreateScene`/`RemoveScene`/`SetSceneName`/`GetSceneList` is already part of FB-42's canvas scope and doesn't merit a separate FB. FB-42's ROADMAP row now explicitly calls out this absorption.


### PR DESCRIPTION
## Summary
Sprint 0.5 is complete — 14 FBs merged. This PR closes the sprint per convention: review the tangent log, promote survivors to new FB numbers, fold obvious subsumptions, and defer the rest with rationale.

## 10 tangent candidates → 6 promotions + 2 folds + 2 deferrals

### New FB items (added to Active Backlog)
| FB | Name | Priority | Effort | Target |
|---|---|---|---|---|
| FB-45 | MCP Sampling | Medium-High | Medium | Sprint 2.0 (proposed anchor) |
| FB-46 | Sampling tool-call loop | Low | Large | Blocked on FB-45 |
| FB-47 | MCP Annotations on tools | Medium | Low | Sprint 1.5 (proposed) |
| FB-48 | MCP Icons | Low-Med | S-M | Sprint 1.5 (proposed) |
| FB-49 | Richer completion context | Low | Small | Unscheduled |
| FB-50 | Deinterlace inputs API | Low | Small | Unscheduled |

### Folds (no new FB)
- **Form/URL elicitation** → FB-32 (ADR-008 Stage 3 already covers it)
- **ToolChoice type** → FB-45 (sampling implementation owns the surface decision)

### Deferred (in tangent log's Rejected/Deferred section)
- **Canvas CRUD beyond `GetCanvasList`** — blocked on upstream goobs write APIs; revisit next goobs bump
- **`canvasUuid` scene-request param** — subsumed by FB-42 scope (FB-42's row now explicitly calls this out)

## Other ROADMAP changes
- Sprint 0.5 marked ✅ Closed 2026-04-18
- Proposed Sprints 1.5 and 2.0 added to the Active Sprints table with candidate anchors
- FB-32 row updated to note ADR-008 shipped + Form/URL elicitation absorbed

## Test plan
- [x] \`go build ./...\`
- [x] \`bash scripts/verify-docs.sh\` — all green (no constant drift since this PR is pure docs)
- [ ] Review each FB-45..FB-50 row for priority/effort calibration before merging